### PR TITLE
support both id and name as identifier for app and function

### DIFF
--- a/aipolabs/common/db/crud/apps.py
+++ b/aipolabs/common/db/crud/apps.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
+from aipolabs.common import utils
 from aipolabs.common.db.sql_models import App
 from aipolabs.common.enums import SecurityScheme, Visibility
 from aipolabs.common.logging import get_logger
@@ -45,8 +46,14 @@ def update_app_default_security_credentials(
     app.default_security_credentials_by_scheme[security_scheme] = security_credentials
 
 
-def get_app(db_session: Session, app_id: UUID, public_only: bool, active_only: bool) -> App | None:
-    statement = select(App).filter_by(id=app_id)
+def get_app(
+    db_session: Session, app_id_or_name: str, public_only: bool, active_only: bool
+) -> App | None:
+    if utils.is_uuid(app_id_or_name):
+        statement = select(App).filter_by(id=app_id_or_name)
+    else:
+        statement = select(App).filter_by(name=app_id_or_name)
+
     if active_only:
         statement = statement.filter(App.active)
     if public_only:

--- a/aipolabs/common/db/crud/functions.py
+++ b/aipolabs/common/db/crud/functions.py
@@ -135,9 +135,12 @@ def get_functions(
 
 
 def get_function(
-    db_session: Session, function_id: UUID, public_only: bool, active_only: bool
+    db_session: Session, function_id_or_name: str, public_only: bool, active_only: bool
 ) -> Function | None:
-    statement = select(Function).filter_by(id=function_id)
+    if utils.is_uuid(function_id_or_name):
+        statement = select(Function).filter_by(id=function_id_or_name)
+    else:
+        statement = select(Function).filter_by(name=function_id_or_name)
 
     # filter out all functions of inactive apps and all inactive functions
     # (where app is active buy specific functions can be inactive)

--- a/aipolabs/common/utils.py
+++ b/aipolabs/common/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+from uuid import UUID
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -61,3 +62,13 @@ def snake_to_camel(string: str) -> str:
     """
     parts = string.split("_")
     return parts[0] + "".join(word.capitalize() for word in parts[1:])
+
+
+def is_uuid(value: str | UUID) -> bool:
+    if isinstance(value, UUID):
+        return True
+    try:
+        UUID(value)
+        return True
+    except ValueError:
+        return False

--- a/aipolabs/server/routes/apps.py
+++ b/aipolabs/server/routes/apps.py
@@ -1,5 +1,4 @@
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 
@@ -96,23 +95,24 @@ async def search_apps(
     return apps
 
 
-@router.get("/{app_id}", response_model=AppBasicWithFunctions)
+@router.get("/{app_id_or_name}", response_model=AppBasicWithFunctions)
 async def get_app_details(
     context: Annotated[deps.RequestContext, Depends(deps.get_request_context)],
-    app_id: UUID,
+    app_id_or_name: str,
 ) -> AppBasicWithFunctions:
     """
     Returns an application (name, description, and functions).
     """
     app = crud.apps.get_app(
         context.db_session,
-        app_id,
+        app_id_or_name,
         context.project.visibility_access == Visibility.PUBLIC,
         True,
     )
+
     if not app:
-        logger.error(f"app={app_id} not found")
-        raise AppNotFound(str(app_id))
+        logger.error(f"app={app_id_or_name} not found")
+        raise AppNotFound(app_id_or_name)
 
     # filter functions by project visibility and active status
     # TODO: better way and place for crud filtering/acl logic like this?

--- a/aipolabs/server/tests/routes/functions/test_functions_execute.py
+++ b/aipolabs/server/tests/routes/functions/test_functions_execute.py
@@ -1,4 +1,5 @@
 import httpx
+import pytest
 import respx
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -42,16 +43,21 @@ def test_execute_non_existent_function(
 
 # Note that if no app configuration or linkedin account is injected to test as fixture,
 # the app will not be configured.
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_whose_app_is_not_configured(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_no_args: Function,
+    identifier_field: str,
 ) -> None:
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_no_args, identifier_field
+    )
     function_execute = FunctionExecute(
         linked_account_owner_id=NON_EXISTENT_LINKED_ACCOUNT_OWNER_ID,
     )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_no_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -59,12 +65,14 @@ def test_execute_function_whose_app_is_not_configured(
     assert response.json()["error"] == "App configuration not found"
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_whose_app_configuration_is_disabled(
     db_session: Session,
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_no_args: Function,
     dummy_app_configuration_api_key_aipolabs_test_project_1: AppConfiguration,
+    identifier_field: str,
 ) -> None:
     dummy_app_configuration_api_key_aipolabs_test_project_1.enabled = False
     db_session.commit()
@@ -72,8 +80,11 @@ def test_execute_function_whose_app_configuration_is_disabled(
     function_execute = FunctionExecute(
         linked_account_owner_id=NON_EXISTENT_LINKED_ACCOUNT_OWNER_ID,
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_no_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_no_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -81,17 +92,22 @@ def test_execute_function_whose_app_configuration_is_disabled(
     assert response.json()["error"] == "App configuration disabled"
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_linked_account_not_found(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_no_args: Function,
     dummy_app_configuration_api_key_aipolabs_test_project_1: AppConfiguration,
+    identifier_field: str,
 ) -> None:
     function_execute = FunctionExecute(
         linked_account_owner_id=NON_EXISTENT_LINKED_ACCOUNT_OWNER_ID,
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_no_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_no_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -99,6 +115,7 @@ def test_execute_function_linked_account_not_found(
     assert response.json()["error"] == "Linked account not found"
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_linked_account_disabled(
     db_session: Session,
     test_client: TestClient,
@@ -106,6 +123,7 @@ def test_execute_function_linked_account_disabled(
     dummy_function_aipolabs_test__hello_world_no_args: Function,
     dummy_app_configuration_api_key_aipolabs_test_project_1: AppConfiguration,
     dummy_linked_account_api_key_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     dummy_linked_account_api_key_aipolabs_test_project_1.enabled = False
     db_session.commit()
@@ -113,8 +131,11 @@ def test_execute_function_linked_account_disabled(
     function_execute = FunctionExecute(
         linked_account_owner_id=dummy_linked_account_api_key_aipolabs_test_project_1.linked_account_owner_id,
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_no_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_no_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -122,18 +143,23 @@ def test_execute_function_linked_account_disabled(
     assert response.json()["error"] == "Linked account disabled"
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_with_invalid_function_input(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_api_key_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     function_execute = FunctionExecute(
         linked_account_owner_id=dummy_linked_account_api_key_aipolabs_test_project_1.linked_account_owner_id,
         function_input={"path": {"random_key": "random_value"}},
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -142,11 +168,13 @@ def test_execute_function_with_invalid_function_input(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_mock_execute_function_with_no_args(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_no_args: Function,
     dummy_linked_account_api_key_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint
     response_data = {"message": "Hello, test_mock_execute_function_with_no_args!"}
@@ -157,9 +185,11 @@ def test_mock_execute_function_with_no_args(
     function_execute = FunctionExecute(
         linked_account_owner_id=dummy_linked_account_api_key_aipolabs_test_project_1.linked_account_owner_id,
     )
-
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_no_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_no_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -172,11 +202,13 @@ def test_mock_execute_function_with_no_args(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_api_key_based_function_with_args(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_api_key_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint
     mock_response_data = {"message": "Hello, test_execute_api_key_based_function_with_args!"}
@@ -199,8 +231,11 @@ def test_execute_api_key_based_function_with_args(
             # "cookie" property is not visible in our test schema so no input here
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -219,11 +254,13 @@ def test_execute_api_key_based_function_with_args(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_api_key_based_function_with_nested_args(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_nested_args: Function,
     dummy_linked_account_api_key_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint
     mock_response_data = {"message": "Hello, test_execute_api_key_based_function_with_nested_args!"}
@@ -248,8 +285,11 @@ def test_execute_api_key_based_function_with_nested_args(
             },
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_nested_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_nested_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -271,11 +311,13 @@ def test_execute_api_key_based_function_with_nested_args(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_oauth2_based_function_with_linked_account_credentials(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_oauth2_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint and response
     mock_response_data = {
@@ -299,8 +341,11 @@ def test_execute_oauth2_based_function_with_linked_account_credentials(
             # "cookie" property is not visible in our test schema so no input here
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -334,12 +379,14 @@ def test_execute_oauth2_based_function_with_linked_account_credentials(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_oauth2_based_function_with_expired_linked_account_access_token(
     db_session: Session,
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_oauth2_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the function's HTTP endpoint and response
     mock_response_data = {
@@ -388,8 +435,11 @@ def test_execute_oauth2_based_function_with_expired_linked_account_access_token(
             # "cookie" property is not visible in our test schema so no input here
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -425,11 +475,13 @@ def test_execute_oauth2_based_function_with_expired_linked_account_access_token(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_oauth2_based_function_with_app_default_credentials(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_default_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint and response
     mock_response_data = {
@@ -453,8 +505,11 @@ def test_execute_oauth2_based_function_with_app_default_credentials(
             # "cookie" property is not visible in our test schema so no input here
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -485,12 +540,14 @@ def test_execute_oauth2_based_function_with_app_default_credentials(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_oauth2_based_function_with_expired_app_default_access_token(
     db_session: Session,
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_function_aipolabs_test__hello_world_with_args: Function,
     dummy_linked_account_default_aipolabs_test_project_1: LinkedAccount,
+    identifier_field: str,
 ) -> None:
     # Mock the HTTP endpoint and response
     mock_response_data = {
@@ -542,8 +599,11 @@ def test_execute_oauth2_based_function_with_expired_app_default_access_token(
             # "cookie" property is not visible in our test schema so no input here
         },
     )
+    function_id_or_name = getattr(
+        dummy_function_aipolabs_test__hello_world_with_args, identifier_field
+    )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_aipolabs_test__hello_world_with_args.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -577,12 +637,14 @@ def test_execute_oauth2_based_function_with_expired_app_default_access_token(
 
 
 @respx.mock
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_with_custom_instructions_success(
     db_session: Session,
     test_client: TestClient,
     dummy_agent_with_github_apple_instructions: Agent,
     dummy_linked_account_api_key_github_project_1: LinkedAccount,
     dummy_function_github__create_repository: Function,
+    identifier_field: str,
 ) -> None:
     # TODO: change needed here when we abstract out to InferenceService
     # Allow real calls to OpenAI API
@@ -604,9 +666,9 @@ def test_execute_function_with_custom_instructions_success(
             }
         },
     )
-
+    function_id_or_name = getattr(dummy_function_github__create_repository, identifier_field)
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_github__create_repository.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_agent_with_github_apple_instructions.api_keys[0].key},
     )
@@ -626,6 +688,7 @@ def test_execute_function_with_custom_instructions_success(
     )
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_execute_function_with_custom_instructions_rejected(
     db_session: Session,
     test_client: TestClient,
@@ -633,6 +696,7 @@ def test_execute_function_with_custom_instructions_rejected(
     dummy_agent_with_github_apple_instructions: Agent,
     dummy_linked_account_api_key_github_project_1: LinkedAccount,
     dummy_function_github__create_repository: Function,
+    identifier_field: str,
 ) -> None:
     function_execute = FunctionExecute(
         linked_account_owner_id=dummy_linked_account_api_key_github_project_1.linked_account_owner_id,
@@ -640,9 +704,9 @@ def test_execute_function_with_custom_instructions_rejected(
             "body": {"name": "apple-test-repo", "description": "Test repository", "private": True}
         },
     )
-
+    function_id_or_name = getattr(dummy_function_github__create_repository, identifier_field)
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_github__create_repository.id}/execute",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/execute",
         json=function_execute.model_dump(mode="json"),
         headers={"x-api-key": dummy_agent_with_github_apple_instructions.api_keys[0].key},
     )

--- a/aipolabs/server/tests/routes/functions/test_functions_get_definition.py
+++ b/aipolabs/server/tests/routes/functions/test_functions_get_definition.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -12,13 +13,18 @@ from aipolabs.common.schemas.function import (
 from aipolabs.server import config
 
 
-def test_get_function_definition_openai(
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
+def test_get_function_definition_openai_by_identifier(
     test_client: TestClient,
     dummy_function_github__create_repository: Function,
     dummy_api_key_1: str,
+    identifier_field: str,
 ) -> None:
+    # Use the specified field (id or name) from the function fixture
+    function_id_or_name = getattr(dummy_function_github__create_repository, identifier_field)
+
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_github__create_repository.id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         params={"inference_provider": "openai"},
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -28,20 +34,24 @@ def test_get_function_definition_openai(
     function_definition = OpenAIFunctionDefinition.model_validate(response_json)
     assert function_definition.type == "function"
     assert function_definition.function.name == dummy_function_github__create_repository.name
-    # sanity check: if description is the same
+    # Sanity check: ensure that the description is the same
     assert (
         function_definition.function.description
         == dummy_function_github__create_repository.description
     )
 
 
-def test_get_function_definition_anthropic(
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
+def test_get_function_definition_anthropic_by_identifier(
     test_client: TestClient,
     dummy_function_github__create_repository: Function,
     dummy_api_key_1: str,
+    identifier_field: str,
 ) -> None:
+    function_id_or_name = getattr(dummy_function_github__create_repository, identifier_field)
+
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_function_github__create_repository.id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         params={"inference_provider": "anthropic"},
         headers={"x-api-key": dummy_api_key_1},
     )
@@ -52,19 +62,22 @@ def test_get_function_definition_anthropic(
     assert function_definition.description == dummy_function_github__create_repository.description
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_get_private_function(
     db_session: Session,
     test_client: TestClient,
     dummy_functions: list[Function],
     dummy_api_key_1: str,
     dummy_project_1: Project,
+    identifier_field: str,
 ) -> None:
     # private function should not be reachable for project with only public access
     crud.functions.set_function_visibility(db_session, dummy_functions[0].id, Visibility.PRIVATE)
     db_session.commit()
 
+    function_id_or_name = getattr(dummy_functions[0], identifier_field)
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -74,25 +87,28 @@ def test_get_private_function(
     db_session.commit()
 
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_200_OK
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_get_function_that_is_under_private_app(
     db_session: Session,
     test_client: TestClient,
     dummy_functions: list[Function],
     dummy_api_key_1: str,
     dummy_project_1: Project,
+    identifier_field: str,
 ) -> None:
     # public function under private app should not be reachable for project with only public access
     crud.apps.set_app_visibility(db_session, dummy_functions[0].app_id, Visibility.PRIVATE)
     db_session.commit()
 
+    function_id_or_name = getattr(dummy_functions[0], identifier_field)
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -102,41 +118,47 @@ def test_get_function_that_is_under_private_app(
     db_session.commit()
 
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_200_OK
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_get_function_that_is_inactive(
     db_session: Session,
     test_client: TestClient,
     dummy_functions: list[Function],
     dummy_api_key_1: str,
+    identifier_field: str,
 ) -> None:
     # inactive function should not be reachable
     crud.functions.set_function_active_status(db_session, dummy_functions[0].id, False)
     db_session.commit()
 
+    function_id_or_name = getattr(dummy_functions[0], identifier_field)
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+@pytest.mark.parametrize("identifier_field", ["id", "name"])
 def test_get_function_that_is_under_inactive_app(
     db_session: Session,
     test_client: TestClient,
     dummy_functions: list[Function],
     dummy_api_key_1: str,
+    identifier_field: str,
 ) -> None:
     # functions (active or inactive) under inactive app should not be reachable
     crud.apps.set_app_active_status(db_session, dummy_functions[0].app_id, False)
     db_session.commit()
 
+    function_id_or_name = getattr(dummy_functions[0], identifier_field)
     response = test_client.get(
-        f"{config.ROUTER_PREFIX_FUNCTIONS}/{dummy_functions[0].id}/definition",
+        f"{config.ROUTER_PREFIX_FUNCTIONS}/{function_id_or_name}/definition",
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
For our APIs that are mostly intended for LLM/Agent to use, using the meaningful name instead of id seems to be more suitable and can simplify sdk implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- API endpoints now support using either a unique identifier or a name when retrieving application and function details, offering greater flexibility and ease of use.
- **Tests**
	- The testing suite has been enhanced with additional parameterization to validate behavior for both identifier types, ensuring robust and consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->