### PR TITLE
fix: Allow frontend to access the accessToken cookie

### DIFF
--- a/aipolabs/server/routes/auth.py
+++ b/aipolabs/server/routes/auth.py
@@ -209,7 +209,7 @@ async def signup_callback(
     response.set_cookie(
         # TODO: need to get rid of this when we switch to secure http cookie authentication
         # Allow the frontend domain to see the accessToken as well
-        domain="platform.aipotheosis.xyz",
+        domain=config.DEV_PORTAL_URL,
         key="accessToken",
         value=jwt_token,
         # httponly=True, # TODO: set after initial release
@@ -286,7 +286,7 @@ async def login_callback(
     response.set_cookie(
         # TODO: need to get rid of this when we switch to secure http cookie authentication
         # Allow the frontend domain to see the accessToken as well
-        domain="platform.aipotheosis.xyz",
+        domain=config.DEV_PORTAL_URL,
         key="accessToken",
         value=jwt_token,
         # httponly=True, # TODO: set after initial release


### PR DESCRIPTION
### 📝 Description

The frontend relies on the `accessToken` cookie being set to check user is logged in and to get the access token for calling backend (see the screenshots below).

This PR explicitly allows the cookie to be available to the dev portal URL.

Local:
<img width="668" alt="Screenshot 2025-02-21 at 10 27 39 PM" src="https://github.com/user-attachments/assets/bdb87fa3-0752-411a-add4-4e65b6188dda" />

Prod:
<img width="695" alt="Screenshot 2025-02-21 at 10 30 40 PM" src="https://github.com/user-attachments/assets/bb6a84ef-8dcc-48d5-8905-a5d589da7d0d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated authentication cookie settings to ensure the correct domain is used for token accessibility on the frontend. Future enhancements for secure HTTP cookie usage have been noted internally. Existing login and signup flows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->