### PR TITLE
fix: Set cookie domain to be the root domain

### DIFF
--- a/.env.shared
+++ b/.env.shared
@@ -17,6 +17,7 @@ SERVER_PROJECT_DAILY_QUOTA=100000
 SERVER_APPLICATION_LOAD_BALANCER_DNS=127.0.0.1
 SERVER_AIPOLABS_REDIRECT_URI_BASE=http://localhost:8000
 SERVER_DEV_PORTAL_URL=http://localhost:3000
+SERVER_AIPOLABS_ROOT_DOMAIN=.localhost
 # Maximum number of users allowed (signup cap)
 SERVER_MAX_USERS=3
 # Comma-separated list of permitted signup codes (e.g., "abc123,def456")

--- a/aipolabs/server/config.py
+++ b/aipolabs/server/config.py
@@ -12,6 +12,7 @@ JWT_ACCESS_TOKEN_EXPIRE_MINUTES = int(
     check_and_get_env_variable("SERVER_JWT_ACCESS_TOKEN_EXPIRE_MINUTES")
 )
 AIPOLABS_REDIRECT_URI_BASE = check_and_get_env_variable("SERVER_AIPOLABS_REDIRECT_URI_BASE")
+AIPOLABS_ROOT_DOMAIN = check_and_get_env_variable("SERVER_AIPOLABS_ROOT_DOMAIN")
 
 # Google Auth
 GOOGLE_AUTH_CLIENT_ID = check_and_get_env_variable("SERVER_GOOGLE_AUTH_CLIENT_ID")

--- a/aipolabs/server/routes/auth.py
+++ b/aipolabs/server/routes/auth.py
@@ -209,7 +209,7 @@ async def signup_callback(
     response.set_cookie(
         # TODO: need to get rid of this when we switch to secure http cookie authentication
         # Allow the frontend domain to see the accessToken as well
-        domain=config.DEV_PORTAL_URL,
+        domain=config.AIPOLABS_ROOT_DOMAIN,
         key="accessToken",
         value=jwt_token,
         # httponly=True, # TODO: set after initial release
@@ -286,7 +286,7 @@ async def login_callback(
     response.set_cookie(
         # TODO: need to get rid of this when we switch to secure http cookie authentication
         # Allow the frontend domain to see the accessToken as well
-        domain=config.DEV_PORTAL_URL,
+        domain=config.AIPOLABS_ROOT_DOMAIN,
         key="accessToken",
         value=jwt_token,
         # httponly=True, # TODO: set after initial release


### PR DESCRIPTION
### 📝 Description

* Set the cookie returned by signup and login endpoint to be available to the `AIPOLABS_ROOT_DOMAIN` env var
  * Locally this root domain is `.localhost`
  * In prod, we have dev portal at `platform.aipolabs.xyz` and server at `api.aipolabs.xyz`, so the `AIPOLABS_ROOT_DOMAIN` should be set to: `.aipolabs.xyz`. See: https://stackoverflow.com/a/1063760
  
  We can get rid of this env var once we switched to session authentication.