### PR TITLE
remove remaining trailing slash residue

### DIFF
--- a/aipolabs/server/routes/auth.py
+++ b/aipolabs/server/routes/auth.py
@@ -297,7 +297,7 @@ async def login_callback(
     return response
 
 
-@router.post("/logout/", include_in_schema=True)
+@router.post("/logout", include_in_schema=True)
 async def logout() -> Response:
     response = Response(status_code=status.HTTP_200_OK)
     response.delete_cookie(

--- a/aipolabs/server/tests/routes/app_configurations/test_app_configurations_get.py
+++ b/aipolabs/server/tests/routes/app_configurations/test_app_configurations_get.py
@@ -27,7 +27,7 @@ def test_get_app_configuration_with_non_existent_app_configuration(
     dummy_api_key_1: str,
     dummy_app_aipolabs_test: App,
 ) -> None:
-    ENDPOINT = f"{config.ROUTER_PREFIX_APP_CONFIGURATIONS}/" f"{dummy_app_aipolabs_test.name}"
+    ENDPOINT = f"{config.ROUTER_PREFIX_APP_CONFIGURATIONS}/{dummy_app_aipolabs_test.name}"
     response = test_client.get(ENDPOINT, headers={"x-api-key": dummy_api_key_1})
 
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/aipolabs/server/tests/routes/app_configurations/test_app_configurations_update.py
+++ b/aipolabs/server/tests/routes/app_configurations/test_app_configurations_update.py
@@ -60,7 +60,7 @@ def test_update_non_existent_app_configuration(
     dummy_api_key_1: str,
     dummy_app_aipolabs_test: App,
 ) -> None:
-    ENDPOINT = f"{config.ROUTER_PREFIX_APP_CONFIGURATIONS}/" f"{dummy_app_aipolabs_test.name}"
+    ENDPOINT = f"{config.ROUTER_PREFIX_APP_CONFIGURATIONS}/{dummy_app_aipolabs_test.name}"
 
     response = test_client.patch(
         ENDPOINT,

--- a/aipolabs/server/tests/routes/auth/test_auth.py
+++ b/aipolabs/server/tests/routes/auth/test_auth.py
@@ -221,7 +221,7 @@ def test_signup_callback_google_user_already_exists(
 def test_logout(test_client: TestClient, db_session: Session) -> None:
     test_client.cookies.set(config.COOKIE_KEY_FOR_AUTH_TOKEN, "randomToken")
 
-    response = test_client.post(f"{config.ROUTER_PREFIX_AUTH}/logout/")
+    response = test_client.post(f"{config.ROUTER_PREFIX_AUTH}/logout")
 
     assert response.status_code == 200
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the logout endpoint URL by removing the trailing slash to provide a more consistent API experience. This change streamlines client interactions with the authentication service—users integrating with the logout functionality should update their requests to match the new endpoint format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->