### PR TITLE
Updated Slack logo url

### DIFF
--- a/apps/slack/app.json
+++ b/apps/slack/app.json
@@ -1,7 +1,7 @@
 {
     "name": "SLACK",
     "display_name": "Slack",
-    "logo": "https://a.slack-edge.com/80588/marketing/img/meta/favicon-32.png",
+    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/slack.svg",
     "provider": "Slack Technologies, LLC, a Salesforce company.",
     "version": "2.33.0",
     "description": "Slack is a team communication and collaboration tool. This API allows you to interact with Slack in two ways: as a bot for automated tasks and workflows, or as a user to perform actions on behalf of a real Slack user. Whether you're building chatbots, automating workflows, or integrating Slack with other tools, this API provides the flexibility to suit your needs.",


### PR DESCRIPTION
Updated Slack's app.json logo url to our own github repo's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Slack application's logo to a new SVG image hosted on GitHub, providing a refreshed visual look without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->