### PR TITLE
rename: Rename GITHUB__GET_SOCIAL_ACCOUNTS_FOR_USER to GITHUB__GET_USER_SOCIAL_ACCOUNTS

### DIFF
--- a/apps/github/functions.json
+++ b/apps/github/functions.json
@@ -129,7 +129,7 @@
         }
     },
     {
-        "name": "GITHUB__GET_SOCIAL_ACCOUNTS_FOR_USER",
+        "name": "GITHUB__GET_USER_SOCIAL_ACCOUNTS",
         "description": "Lists social media accounts for a user",
         "tags": ["user", "social"],
         "visibility": "public",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated our GitHub integration for improved naming consistency while ensuring the social account retrieval feature remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->