### PR TITLE
fix: Allow localhost:3000 in CORS to support frontend development against production server

### DIFF
--- a/aipolabs/server/main.py
+++ b/aipolabs/server/main.py
@@ -87,7 +87,7 @@ app.add_middleware(SessionMiddleware, secret_key=config.SIGNING_KEY)
 # )
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[config.DEV_PORTAL_URL],
+    allow_origins=[config.DEV_PORTAL_URL, "http://localhost:3000"],
     allow_credentials=True,
     allow_methods=["GET", "POST", "DELETE", "PATCH"],
     allow_headers=["Authorization", "X-API-KEY"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the API’s cross-origin support by allowing requests from the local development environment, enhancing integration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->