### PR TITLE
add update endpoint for linked account

### DIFF
--- a/aipolabs/common/db/crud/linked_accounts.py
+++ b/aipolabs/common/db/crud/linked_accounts.py
@@ -7,6 +7,7 @@ from aipolabs.common import validators
 from aipolabs.common.db.sql_models import App, LinkedAccount
 from aipolabs.common.enums import SecurityScheme
 from aipolabs.common.logging import get_logger
+from aipolabs.common.schemas.linked_accounts import LinkedAccountUpdate
 from aipolabs.common.schemas.security_scheme import (
     APIKeySchemeCredentials,
     NoAuthSchemeCredentials,
@@ -51,7 +52,8 @@ def get_linked_account(
     return linked_account
 
 
-def get_linked_account_by_id(
+# TODO: the access control (project_id check) should probably be done at the route level?
+def get_linked_account_by_id_under_project(
     db_session: Session, linked_account_id: UUID, project_id: UUID
 ) -> LinkedAccount | None:
     """Get a linked account by its id, with optional project filter
@@ -118,6 +120,18 @@ def update_linked_account_credentials(
     )
 
     linked_account.security_credentials = security_credentials.model_dump(mode="json")
+    db_session.flush()
+    db_session.refresh(linked_account)
+    return linked_account
+
+
+def update_linked_account(
+    db_session: Session,
+    linked_account: LinkedAccount,
+    linked_account_update: LinkedAccountUpdate,
+) -> LinkedAccount:
+    if linked_account_update.enabled is not None:
+        linked_account.enabled = linked_account_update.enabled
     db_session.flush()
     db_session.refresh(linked_account)
     return linked_account

--- a/aipolabs/common/schemas/linked_accounts.py
+++ b/aipolabs/common/schemas/linked_accounts.py
@@ -27,6 +27,10 @@ class LinkedAccountNoAuthCreate(LinkedAccountCreateBase):
     pass
 
 
+class LinkedAccountUpdate(BaseModel):
+    enabled: bool | None = None
+
+
 class LinkedAccountOAuth2CreateState(BaseModel):
     project_id: UUID
     app_name: str

--- a/aipolabs/server/tests/routes/linked_acounts/test_accounts_update.py
+++ b/aipolabs/server/tests/routes/linked_acounts/test_accounts_update.py
@@ -1,0 +1,65 @@
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from aipolabs.common.db.sql_models import LinkedAccount
+from aipolabs.common.schemas.linked_accounts import LinkedAccountPublic, LinkedAccountUpdate
+from aipolabs.server import config
+
+NON_EXISTENT_LINKED_ACCOUNT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def test_update_linked_account(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_linked_account_oauth2_google_project_1: LinkedAccount,
+) -> None:
+    ENDPOINT = (
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/{dummy_linked_account_oauth2_google_project_1.id}"
+    )
+
+    assert dummy_linked_account_oauth2_google_project_1.enabled, (
+        "linked account should be enabled by default"
+    )
+
+    linked_account_update = LinkedAccountUpdate(enabled=False)
+    response = test_client.patch(
+        ENDPOINT, headers={"x-api-key": dummy_api_key_1}, json=linked_account_update.model_dump()
+    )
+    assert response.status_code == status.HTTP_200_OK
+    linked_account_response = LinkedAccountPublic.model_validate(response.json())
+    assert linked_account_response.enabled == linked_account_update.enabled
+
+
+def test_update_linked_account_not_found(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_linked_account_oauth2_google_project_2: LinkedAccount,
+) -> None:
+    ENDPOINT = f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/{NON_EXISTENT_LINKED_ACCOUNT_ID}"
+
+    linked_account_update = LinkedAccountUpdate(enabled=False)
+    response = test_client.patch(
+        ENDPOINT, headers={"x-api-key": dummy_api_key_1}, json=linked_account_update.model_dump()
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_linked_account_not_belong_to_project(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_linked_account_oauth2_google_project_1: LinkedAccount,
+    dummy_linked_account_oauth2_google_project_2: LinkedAccount,
+) -> None:
+    ENDPOINT = (
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/{dummy_linked_account_oauth2_google_project_2.id}"
+    )
+
+    linked_account_update = LinkedAccountUpdate(enabled=False)
+
+    response = test_client.patch(
+        ENDPOINT, headers={"x-api-key": dummy_api_key_1}, json=linked_account_update.model_dump()
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, (
+        "updating linked account that does not belong to the project should return 404"
+    )


### PR DESCRIPTION
### 🏷️ Notion Ticket

[https://www.notion.so/endpoint-for-updating-linked-account-1b28378d6a47800a88c2dbee6e29a212]

### 📝 Description
- endpoint for updating linked account: for now only support toggle enabled status
- add test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new update capability for linked accounts, enabling real-time modifications to account status.
  - Improved security by ensuring that linked account changes are validated within the proper project context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->