### PR TITLE
update icon url for steel

### DIFF
--- a/apps/steel/app.json
+++ b/apps/steel/app.json
@@ -1,7 +1,7 @@
 {
     "name": "STEEL",
     "display_name": "Steel.dev",
-    "logo": "https://github.com/steel-dev/steel-browser/raw/main/images/steel_header_logo.png",
+    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/steel.png",
     "provider": "Steel.dev",
     "version": "1.0.0",
     "description": "API for browser automation, web scraping, screenshot capture, and PDF generation with session management capabilities.",


### PR DESCRIPTION
### 🏷️ Notion Ticket

https://www.notion.so/steel-dev-1c18378d6a47804abd38d3f89892bf4b?pvs=4

### 📝 Description

This is a url link update for `logo` parameter in `apps/steel/app.json`, the link has been updated using the logo provided by `aipolabs-icons` repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application's logo to a new image asset, refreshing the visual branding without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->