### PR TITLE
feat: add cognito_forms app

### DIFF
--- a/apps/cognito_forms/app.json
+++ b/apps/cognito_forms/app.json
@@ -1,0 +1,24 @@
+{
+    "name": "COGNITO_FORMS",
+    "display_name": "Cognito Forms",
+    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/cognito_forms.svg",
+    "provider": "Cognito LLC",
+    "version": "1.0.0",
+    "description": "Cognito Forms is a powerful online form builder that allows users to create custom forms, collect data, and automatically process payments. The tool supports complex field types, conditional logic, calculated fields, file uploads, and multiple integration options.",
+    "security_schemes": {
+        "api_key": {
+            "location": "header",
+            "name": "Authorization",
+            "prefix": null
+        }
+    },
+    "default_security_credentials_by_scheme": {},
+    "categories": [
+        "forms",
+        "data-collection",
+        "workflow",
+        "productivity"
+    ],
+    "visibility": "public",
+    "active": true
+}

--- a/apps/cognito_forms/functions.json
+++ b/apps/cognito_forms/functions.json
@@ -1,0 +1,421 @@
+[
+	{
+		"name": "COGNITO_FORMS__GET_FORMS",
+		"description": "Retrieves a list of all forms within the authenticated organization.",
+		"tags": [
+			"cognito",
+			"forms"
+		],
+		"visibility": "public",
+		"active": true,
+		"protocol": "rest",
+		"protocol_data": {
+			"method": "GET",
+			"path": "/forms",
+			"server_url": "https://www.cognitoforms.com/api"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "object",
+					"description": "Query parameters for filtering, sorting, and pagination.",
+					"properties": {
+						"filter": {
+							"type": "string",
+							"description": "OData-style filter expression to filter forms."
+						},
+						"orderby": {
+							"type": "string",
+							"description": "OData-style order expression to sort forms."
+						},
+						"top": {
+							"type": "integer",
+							"description": "Maximum number of forms to return."
+						},
+						"skip": {
+							"type": "integer",
+							"description": "Number of forms to skip before starting to collect the result set."
+						}
+					},
+					"required": [],
+					"visible": [
+						"filter",
+						"orderby",
+						"top",
+						"skip"
+					],
+					"additionalProperties": false
+				},
+				"header": {
+					"type": "object",
+					"description": "Header parameters for authentication.",
+					"properties": {
+						"Authorization": {
+							"type": "string",
+							"description": "Authorization token for API authentication."
+						}
+					},
+					"required": [
+						"Authorization"
+					],
+					"visible": [
+						"Authorization"
+					],
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"header"
+			],
+			"visible": [
+				"query"
+			],
+			"additionalProperties": false
+		}
+	},
+	{
+		"name": "COGNITO_FORMS__POST_FORM_ENTRIES",
+		"description": "Creates a new entry for the specified form. The entry fields must match the form's expected structure.",
+		"tags": [
+			"cognito",
+			"entries"
+		],
+		"visibility": "public",
+		"active": true,
+		"protocol": "rest",
+		"protocol_data": {
+			"method": "POST",
+			"path": "/forms/1/entries",
+			"server_url": "https://www.cognitoforms.com/api"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "object",
+					"description": "Path parameters",
+					"properties": {
+						"formId": {
+							"type": "string",
+							"description": "The ID of the form to which the entry will be submitted."
+						}
+					},
+					"required": [
+						"formId"
+					],
+					"visible": [
+						"formId"
+					],
+					"additionalProperties": false
+				},
+				"header": {
+					"type": "object",
+					"description": "Header parameters for authentication.",
+					"properties": {
+						"Authorization": {
+							"type": "string",
+							"description": "Bearer token for API authentication."
+						},
+						"Content-Type": {
+							"type": "string",
+							"description": "Content type header. Should be 'application/json'.",
+							"default": "application/json"
+						}
+					},
+					"required": [
+						"Authorization"
+					],
+					"visible": [
+						"Authorization"
+					],
+					"additionalProperties": false
+				},
+				"body": {
+					"type": "object",
+					"description": "The entry data to be submitted. Field names must match those defined in the form.",
+					"properties": {
+						"Name": {
+							"type": "string",
+							"description": "Example form field: Name of the person."
+						},
+						"Email": {
+							"type": "string",
+							"description": "Example form field: Email address."
+						},
+						"Phone": {
+							"type": "string",
+							"description": "Example form field: Contact number."
+						}
+					},
+					"required": [],
+					"visible": [
+						"Name",
+						"Email",
+						"Phone"
+					],
+					"additionalProperties": true
+				}
+			},
+			"required": [
+				"path",
+				"header",
+				"body"
+			],
+			"visible": [
+				"path",
+				"body"
+			],
+			"additionalProperties": false
+		}
+	},
+	{
+		"name": "COGNITO_FORMS__GET_FORM_ENTRY",
+		"description": "Retrieves a single entry by its ID for a given form.",
+		"tags": [
+			"cognito",
+			"entries"
+		],
+		"visibility": "public",
+		"active": true,
+		"protocol": "rest",
+		"protocol_data": {
+			"method": "GET",
+			"path": "/forms/{formId}/entries/{entryId}",
+			"server_url": "https://www.cognitoforms.com/api"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "object",
+					"description": "Path parameters",
+					"properties": {
+						"formId": {
+							"type": "string",
+							"description": "The ID of the form containing the entry."
+						},
+						"entryId": {
+							"type": "string",
+							"description": "The ID of the entry to retrieve."
+						}
+					},
+					"required": [
+						"formId",
+						"entryId"
+					],
+					"visible": [
+						"formId",
+						"entryId"
+					],
+					"additionalProperties": false
+				},
+				"header": {
+					"type": "object",
+					"description": "Header parameters for authentication.",
+					"properties": {
+						"Authorization": {
+							"type": "string",
+							"description": "Bearer token for API authentication."
+						},
+						"Content-Type": {
+							"type": "string",
+							"description": "Content type header. Should be 'application/json'.",
+							"default": "application/json"
+						}
+					},
+					"required": [
+						"Authorization"
+					],
+					"visible": [
+						"Authorization"
+					],
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"path",
+				"header"
+			],
+			"visible": [
+				"path"
+			],
+			"additionalProperties": false
+		}
+	},
+	{
+		"name": "COGNITO_FORMS__DELETE_FORM_ENTRY",
+		"description": "Deletes a specific entry by its ID from the given form.",
+		"tags": [
+			"cognito",
+			"entries"
+		],
+		"visibility": "public",
+		"active": true,
+		"protocol": "rest",
+		"protocol_data": {
+			"method": "DELETE",
+			"path": "/forms/{formId}/entries/{entryId}",
+			"server_url": "https://www.cognitoforms.com/api"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "object",
+					"description": "Path parameters for identifying the form and entry.",
+					"properties": {
+						"formId": {
+							"type": "string",
+							"description": "The ID of the form."
+						},
+						"entryId": {
+							"type": "string",
+							"description": "The ID of the entry to delete."
+						}
+					},
+					"required": [
+						"formId",
+						"entryId"
+					],
+					"visible": [
+						"formId",
+						"entryId"
+					],
+					"additionalProperties": false
+				},
+				"header": {
+					"type": "object",
+					"description": "Header parameters for authentication.",
+					"properties": {
+						"Authorization": {
+							"type": "string",
+							"description": "Bearer token for API authentication."
+						},
+						"Content-Type": {
+							"type": "string",
+							"description": "Content type header. Should be 'application/json'.",
+							"default": "application/json"
+						}
+					},
+					"required": [
+						"Authorization"
+					],
+					"visible": [
+						"Authorization"
+					],
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"path",
+				"header"
+			],
+			"visible": [
+				"path"
+			],
+			"additionalProperties": false
+		}
+	},
+	{
+		"name": "COGNITO_FORMS__PATCH_FORM_ENTRY",
+		"description": "Updates an existing entry by its ID for a given form. Only the specified fields in the request body will be updated.",
+		"tags": [
+			"cognito",
+			"entries"
+		],
+		"visibility": "public",
+		"active": true,
+		"protocol": "rest",
+		"protocol_data": {
+			"method": "PATCH",
+			"path": "/forms/{formId}/entries/{entryId}",
+			"server_url": "https://www.cognitoforms.com/api"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "object",
+					"description": "Path parameters",
+					"properties": {
+						"formId": {
+							"type": "string",
+							"description": "The ID of the form containing the entry."
+						},
+						"entryId": {
+							"type": "string",
+							"description": "The ID of the entry to update."
+						}
+					},
+					"required": [
+						"formId",
+						"entryId"
+					],
+					"visible": [
+						"formId",
+						"entryId"
+					],
+					"additionalProperties": false
+				},
+				"header": {
+					"type": "object",
+					"description": "Header parameters for authentication.",
+					"properties": {
+						"Authorization": {
+							"type": "string",
+							"description": "Bearer token for API authentication."
+						},
+						"Content-Type": {
+							"type": "string",
+							"description": "Content type header. Should be 'application/json'.",
+							"default": "application/json"
+						}
+					},
+					"required": [
+						"Authorization"
+					],
+					"visible": [
+						"Authorization"
+					],
+					"additionalProperties": false
+				},
+				"body": {
+					"type": "object",
+					"description": "The entry data to be updated. Only include the fields that need to be updated.",
+					"properties": {
+						"Name": {
+							"type": "string",
+							"description": "Updated name of the person."
+						},
+						"Email": {
+							"type": "string",
+							"description": "Updated email address."
+						},
+						"Phone": {
+							"type": "string",
+							"description": "Updated contact number."
+						}
+					},
+					"required": [],
+					"visible": [
+						"Name",
+						"Email",
+						"Phone"
+					],
+					"additionalProperties": true
+				}
+			},
+			"required": [
+				"path",
+				"header",
+				"body"
+			],
+			"visible": [
+				"path",
+				"body"
+			],
+			"additionalProperties": false
+		}
+	}
+]


### PR DESCRIPTION
### Summary
General introduction about this PR and this APP

APP_URL: https://www.cognitoforms.com/
APP_API_DOCS_URL: https://www.cognitoforms.com/support/475/data-integration/cognito-forms-api

### Integrated API
COGNITO_FORMS__GET_FORMS
COGNITO_FORMS__POST_FORM_ENTRIES
COGNITO_FORMS__GET_FORM_ENTRY
COGNITO_FORMS__DELETE_FORM_ENTRY
COGNITO_FORMS__PATCH_FORM_ENTRY

### Fuzzy Tests
``` cmd
docker compose exec runner python -m aipolabs.cli.aipolabs fuzzy-test-function-execution --function-name <函数名字> --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --aipolabs-api-key <AIPOLABS_API_KEY> --prompt "<告诉gpt要做什么>"
```

```cmd
```

```cmd
```

```cmd
```

### Videos
{ 测试视频，或者完整的截图, 从编辑框的附件按钮提交文件 }



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new integration for an online form builder with enhanced configuration details, including application metadata and branding.
	- Added secure API endpoints that enable form management, such as retrieving forms, creating new entries, and updating or deleting existing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->