### PR TITLE
Fix pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,19 +16,19 @@ repos:
       - id: format check
         name: running dev portal format check
         language: system
-        entry: cd frontend && npm run format
+        entry: sh -c "cd frontend && npm run format"
         pass_filenames: false
         require_serial: true
       - id: lint check
         name: running dev portal lint check
         language: system
-        entry: cd frontend && npm run lint
+        entry: sh -c "cd frontend && npm run lint"
         pass_filenames: false
         require_serial: true
       - id: test check
         name: running dev portal test check
         language: system
-        entry: cd frontend && npm run test:run
+        entry: sh -c "cd frontend && npm run test:run"
         pass_filenames: false
         require_serial: true
 
@@ -38,18 +38,18 @@ repos:
       - id: format
         name: running backend format checks
         language: system
-        entry: cd backend && uv run ruff format .
+        entry: sh -c "cd backend && uv run ruff format ."
         pass_filenames: false
         require_serial: true
       - id: lint
         name: running backend lint checks
         language: system
-        entry: cd backend && uv run ruff check . --fix
+        entry: sh -c "cd backend && uv run ruff check . --fix"
         pass_filenames: false
         require_serial: true
       - id: mypy
         name: running backend mypy checks
         language: system
-        entry: cd backend && uv run mypy .
+        entry: sh -c "cd backend && uv run mypy ."
         pass_filenames: false
         require_serial: true


### PR DESCRIPTION
Triggered the failure locally to verify pre-commit hooks do run after the fix:
```shell
❯ gcmsg "test"
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for added large files..............................................Passed
check for merge conflicts................................................Passed
running dev portal format check..........................................Passed
running dev portal lint check............................................Passed
running dev portal test check............................................Passed
running backend format checks............................................Passed
running backend lint checks..............................................Passed
running backend mypy checks..............................................Failed
- hook id: mypy
- exit code: 1

aci/common/config.py:10: error: Incompatible return value type (got "int", expected "str")  [return-value]
Found 1 error in 1 file (checked 161 source files)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit hook commands to improve shell execution compatibility for frontend and backend checks. No changes to application features or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->