### PR TITLE
hide default_account_linking api

### DIFF
--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -66,7 +66,7 @@ There are a few tricky parts:
 """
 
 
-@router.post("/default", response_model=LinkedAccountPublic)
+@router.post("/default", response_model=LinkedAccountPublic, include_in_schema=False)
 async def link_account_with_aci_default_credentials(
     context: Annotated[deps.RequestContext, Depends(deps.get_request_context)],
     body: Annotated[LinkedAccountDefaultCreate, Body()],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - The POST endpoint at `/default` is now hidden from the automatically generated API documentation. This does not affect its functionality or availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->