### PR TITLE
remove local dev in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ ACI.dev solves your critical infrastructure challenges for production-ready AI a
 - **Outbound Sales Agent:** Automates lead generation, email outreach, and CRM updates.
 - **Customer Support Agent:** Provides answers, manages tickets, and performs actions based on customer queries.
 
----
 
 ## Repository Structure
 
@@ -65,115 +64,33 @@ This is a monorepo that contains the core components of ACI.dev:
 - **`/backend`**: Contains the main ACI platform server, including the APIs, core logic, database models, and the entire integration library (over 600+ tools). It relies on Python, FastAPI, PostgreSQL (with pgvector), and Docker.
 - **`/frontend`**: Contains the Next.js application for the ACI.dev Developer Portal. This is the web interface for managing projects, integrations, authentication, and testing agents. It uses React, TypeScript, Tailwind CSS, and interacts with the backend API.
 
----
 
 ## Getting Started: Local Development
 
-To run the full ACI.dev platform (backend server and frontend portal) locally, follow these steps:
+To run the full ACI.dev platform (backend server and frontend portal) locally, follow the individual README files for each component:
 
-### Prerequisites
+- **Backend:** [backend/README.md](backend/README.md)
+- **Frontend:** [frontend/README.md](frontend/README.md)
 
-- **Git:** To clone the repository.
-- **Docker & Docker Compose:** To run the backend services (server, database, localstack).
-- **Python:** Version 3.12 or higher (primarily for development tooling like linters, if not using Docker exclusively).
-- **uv:** Python package manager (`pip install uv`). Used for managing backend Python dependencies.
-- **Node.js & npm:** To run the frontend developer portal (check `frontend/package.json` for specific version requirements, likely latest LTS).
-- **(Optional) ngrok:** If you need to test PropelAuth webhooks for user signups locally.
 
-### 1. Backend Setup
-
-1. **Navigate to the backend directory:**
-
-    ```bash
-    cd backend
-    ```
-
-2. **Install Python dependencies (optional, recommended for IDE integration):**
-
-    ```bash
-    uv sync
-    # Activate virtual environment (optional)
-    source .venv/bin/activate
-    ```
-
-3. **Set up environment variables:**
-    Copy `.env.example` to `.env`. Most necessary variables are pre-filled in `.env.shared`, but you might need to add specific secrets like `SERVER_PROPELAUTH_API_KEY` or `SERVER_SVIX_SIGNING_SECRET` if testing webhooks (see `backend/README.md` for details).
-4. **Start backend services:**
-
-    ```bash
-    docker compose up --build
-    ```
-
-    This will start the ACI server (port 8000), PostgreSQL database, and a LocalStack container (for mocking AWS services).
-
-    - The API documentation (Swagger UI) will be available at `http://localhost:8000/v1/notforhuman-docs`.
-    - See `backend/README.md` for optional steps like seeding the database or running tests.
-
-### 2. Frontend Setup
-
-1. **Navigate to the frontend directory:**
-
-    ```bash
-    cd ../frontend # Or from the root: cd frontend
-    ```
-
-2. **Install Node.js dependencies:**
-
-    ```bash
-    npm install --legacy-peer-deps
-    ```
-
-    *(Note: The `--legacy-peer-deps` flag might be needed due to ongoing React 19 adoption by libraries, as mentioned in `frontend/README.md`).*
-3. **Set up environment variables:**
-    Create a `.env` file in the `frontend` directory with the following content:
-
-    ```env
-    NEXT_PUBLIC_API_URL=http://localhost:8000
-    NEXT_PUBLIC_DEV_PORTAL_URL=http://localhost:3000
-    NEXT_PUBLIC_ENVIRONMENT=local
-    NEXT_PUBLIC_AUTH_URL=https://217353629.propelauthtest.com
-    ```
-
-    *(Adjust `NEXT_PUBLIC_API_URL` if your backend runs on a different port).*
-4. **Start the frontend development server:**
-
-    ```bash
-    npm run dev
-    ```
-
-    The Developer Portal should now be accessible at `http://localhost:3000`.
-
-### 3. Further Details
-
-For more in-depth information, including advanced configuration (like webhook setup), coding standards, testing, database migrations, and deployment details, please refer to the specific README files:
-
-- **Backend:** `backend/README.md`
-- **Frontend:** `frontend/README.md`
-
----
-
-## Tech Stack
+## Tech Stack (local)
 
 - **Backend:**
   - **Language:** Python 3.12+
   - **Framework:** FastAPI
-  - **Database:** PostgreSQL with the `pgvector` extension (for vector similarity search)
+  - **Database:** PostgreSQL
   - **ORM:** SQLAlchemy with Alembic for migrations
   - **Dependency Management:** uv
   - **Testing:** Pytest
   - **Linting/Formatting:** Ruff, MyPy
+  - **Containerization:** Docker & Docker Compose
+  - **Local AWS Mocking:** LocalStack
 - **Frontend:**
-  - **Framework:** Next.js (using App Router)
+  - **Framework:** Next.js (App Router)
   - **Language:** TypeScript
   - **UI Library:** React 19
   - **Styling:** Tailwind CSS
   - **Component Library:** shadcn/ui
-  - **Package Manager:** npm
   - **Testing:** Vitest
   - **Linting/Formatting:** ESLint, Prettier
-- **Authentication:** PropelAuth (Handles user login, sign-up, and organization management)
-- **Infrastructure:**
-  - **Containerization:** Docker & Docker Compose
-  - **Local AWS Mocking:** LocalStack (for services like Secrets Manager)
-
----
+- **Authentication:** PropelAuth


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the main README by removing detailed local setup instructions and directing users to backend and frontend READMEs.
  - Consolidated and clarified the tech stack section, including updates to tool listings and formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->