### PR TITLE
refactor: update custom_instructions to use functionName only as key

### DIFF
--- a/frontend/src/components/project/agent-instruction-filter-form.tsx
+++ b/frontend/src/components/project/agent-instruction-filter-form.tsx
@@ -131,7 +131,7 @@ export function AgentInstructionFilterForm({
     functionName: string,
     value: string,
   ) => {
-    const key = `${appName}:${functionName}`;
+    const key = `${functionName}`;
     setInstructions((prev) => ({
       ...prev,
       [key]: value,
@@ -140,7 +140,7 @@ export function AgentInstructionFilterForm({
 
   // Get instruction for specific App function
   const getInstruction = (appName: string, functionName: string) => {
-    const key = `${appName}:${functionName}`;
+    const key = `${functionName}`;
     return instructions[key] || "";
   };
 
@@ -151,7 +151,7 @@ export function AgentInstructionFilterForm({
       const currentInstructions = { ...instructions };
 
       // Get instruction key
-      const key = `${appName}:${functionName}`;
+      const key = `${functionName}`;
 
       // If instruction is empty, remove it from instructions set
       if (!currentInstructions[key] || currentInstructions[key].trim() === "") {
@@ -189,7 +189,7 @@ export function AgentInstructionFilterForm({
       const currentInstructions = { ...instructions };
 
       // Get instruction key
-      const key = `${appName}:${functionName}`;
+      const key = `${functionName}`;
 
       // Remove the instruction
       delete currentInstructions[key];


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

- Update all relevant logic in AgentInstructionFilterForm to use only functionName as the key for custom_instructions
- Drop appName: prefix to simplify key format

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/fe4bb9cf-d82f-4608-b80d-c6a835e6b914)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ✔] All checks on CI passed
