### PR TITLE
add tooltip for SettingsSidebar in playground page

### DIFF
--- a/frontend/src/app/playground/setting-agent-selector.tsx
+++ b/frontend/src/app/playground/setting-agent-selector.tsx
@@ -10,7 +10,12 @@ import {
 import { useAgentStore } from "@/lib/store/agent";
 import { Agent } from "@/lib/types/project";
 import { Message } from "ai";
-
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { BsQuestionCircle } from "react-icons/bs";
 interface AgentSelectorProps {
   agents: Agent[];
   setMessages: (messages: Message[]) => void;
@@ -35,7 +40,21 @@ export function AgentSelector({ agents, setMessages }: AgentSelectorProps) {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium">Agent</h3>
+      <Tooltip>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Agent</h3>
+          <TooltipTrigger asChild>
+            <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
+          </TooltipTrigger>
+        </div>
+        <TooltipContent>
+          <p>
+            Select the agent you want to test, can create new ones in manage
+            account.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+
       {!hasAgents ? (
         <div className="text-sm text-muted-foreground p-2 border rounded-md">
           No agents available

--- a/frontend/src/app/playground/setting-app-selector.tsx
+++ b/frontend/src/app/playground/setting-app-selector.tsx
@@ -25,7 +25,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { BsQuestionCircle } from "react-icons/bs";
 // Maximum number of apps that can be selected
 const MAX_APPS = 6;
 
@@ -105,7 +110,20 @@ export function AppMultiSelector() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium">Apps</h3>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium">Apps</h3>
+            <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Select from the agent&apos;s enabled apps, check manage account
+            panel.
+          </p>
+        </TooltipContent>
+      </Tooltip>
       <Popover open={open} onOpenChange={setOpen} key="app-selector-popover">
         <PopoverTrigger asChild>
           <Button

--- a/frontend/src/app/playground/setting-app-selector.tsx
+++ b/frontend/src/app/playground/setting-app-selector.tsx
@@ -111,12 +111,12 @@ export function AppMultiSelector() {
   return (
     <div className="space-y-2">
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex items-center gap-2">
-            <h3 className="text-sm font-medium">Apps</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Apps</h3>
+          <TooltipTrigger asChild>
             <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
-          </div>
-        </TooltipTrigger>
+          </TooltipTrigger>
+        </div>
         <TooltipContent>
           <p>
             Select from the agent&apos;s enabled apps, check manage account

--- a/frontend/src/app/playground/setting-function-selector.tsx
+++ b/frontend/src/app/playground/setting-function-selector.tsx
@@ -24,7 +24,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { BsQuestionCircle } from "react-icons/bs";
 export function FunctionMultiSelector() {
   const [open, setOpen] = useState(false);
   const [functions, setFunctions] = useState<AppFunction[]>([]);
@@ -85,7 +90,17 @@ export function FunctionMultiSelector() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium">Functions</h3>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium">Functions</h3>
+            <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Select functions from selected apps.</p>
+        </TooltipContent>
+      </Tooltip>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button

--- a/frontend/src/app/playground/setting-function-selector.tsx
+++ b/frontend/src/app/playground/setting-function-selector.tsx
@@ -91,12 +91,12 @@ export function FunctionMultiSelector() {
   return (
     <div className="space-y-2">
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex items-center gap-2">
-            <h3 className="text-sm font-medium">Functions</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Functions</h3>
+          <TooltipTrigger asChild>
             <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
-          </div>
-        </TooltipTrigger>
+          </TooltipTrigger>
+        </div>
         <TooltipContent>
           <p>Select functions from selected apps.</p>
         </TooltipContent>

--- a/frontend/src/app/playground/setting-linked-account-owner-id-selector.tsx
+++ b/frontend/src/app/playground/setting-linked-account-owner-id-selector.tsx
@@ -9,7 +9,12 @@ import {
 } from "@/components/ui/select";
 import { useAgentStore } from "@/lib/store/agent";
 import { Message } from "ai";
-
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { BsQuestionCircle } from "react-icons/bs";
 interface LinkAccountOwnerIdSelectorProps {
   linkedAccounts: { linked_account_owner_id: string }[];
   status: string;
@@ -30,7 +35,17 @@ export function LinkAccountOwnerIdSelector({
 
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium">Linked Account Owner ID</h3>
+      <Tooltip>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Linked Account Owner ID</h3>
+          <TooltipTrigger asChild>
+            <BsQuestionCircle className="h-4 w-4 text-muted-foreground" />
+          </TooltipTrigger>
+        </div>
+        <TooltipContent>
+          <p>Select which user you want to test the agent as.</p>
+        </TooltipContent>
+      </Tooltip>
       <Select
         value={linkedAccountOwnerId}
         onValueChange={resetLinkedAccountOwnerId}


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description
Add tooltip descriptions to controls in the SettingsSidebar on the Playground page to improve user guidance and clarity.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c597f934-82fe-4d0d-a2a8-7184f3c15b78)
![image](https://github.com/user-attachments/assets/af5618aa-a766-45ee-bc2d-31eaa7343442)
![image](https://github.com/user-attachments/assets/4730e576-a2cf-4f04-8e87-25f887eb5135)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
