### PR TITLE
feat: Add a button to copy all allowed apps

### DIFF
--- a/frontend/src/components/apps/id-display.tsx
+++ b/frontend/src/components/apps/id-display.tsx
@@ -64,7 +64,7 @@ export function IdDisplay({ id, dim = true }: IdDisplayProps) {
             </button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Copy ID to clipboard</p>
+            <p>Copy to clipboard</p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/frontend/src/components/project/app-edit-form.tsx
+++ b/frontend/src/components/project/app-edit-form.tsx
@@ -20,6 +20,7 @@ import { AppConfig } from "@/lib/types/appconfig";
 import { getApiKey } from "@/lib/api/util";
 import { toast } from "sonner";
 import { useMetaInfo } from "@/components/context/metainfo";
+import { IdDisplay } from "../apps/id-display";
 interface AppEditFormProps {
   children: React.ReactNode;
   reload: () => Promise<void>;
@@ -132,7 +133,14 @@ export function AppEditForm({
             Change what apps agents have access to.
           </p>
           <Separator />
-          <h3 className="text-sm font-medium">Select enabled app(s)</h3>
+          <h3 className="text-sm font-medium">
+            Select enabled app(s)
+            {selectedApps.length > 0 && (
+              <div className="max-w-[300px] truncate">
+                <IdDisplay id={selectedApps.join(",")} />
+              </div>
+            )}
+          </h3>
 
           {selectedApps.length > 0 && (
             <div className="flex flex-wrap gap-2 p-2 rounded-md overflow-y-auto max-h-16 border">


### PR DESCRIPTION
### 📝 Description

This button allows users to copy all enabled apps for an agent in one click in the format of: `GITHUB,GOOGLE_CALENDAR,GOOGLE_DOCS`. This is especially useful when users are configuring the apps MCP server where they need to specify all enabled apps in the MCP definition.

### 📸 Screenshots (if applicable)

<img width="484" alt="Screenshot 2025-04-22 at 6 10 32 PM" src="https://github.com/user-attachments/assets/08a15724-0b9b-45e0-b963-31c118dbbc92" />

<img width="906" alt="Screenshot 2025-04-22 at 6 10 28 PM" src="https://github.com/user-attachments/assets/748947c7-eaaf-4fa7-885f-00d2cfcda7a5" />

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual display of selected app IDs in the "Select enabled app(s)" section for easier reference.

- **Style**
  - Updated the tooltip text for the copy button to "Copy to clipboard" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->