### PR TITLE
feat:support change agent on agent playground

### DIFF
--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMetaInfo } from "@/components/context/metainfo";
-import { getApiKey } from "@/lib/api/util";
 import { useChat } from "@ai-sdk/react";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
@@ -25,9 +24,10 @@ const Page = () => {
     setLinkedAccountOwnerId,
     setSelectedAgent,
     setAllowedApps,
+    getApiKey,
   } = useAgentStore();
 
-  const apiKey = activeProject ? getApiKey(activeProject) : "";
+  const apiKey = getApiKey(activeProject);
 
   const {
     messages,

--- a/frontend/src/app/playground/playground-settings.tsx
+++ b/frontend/src/app/playground/playground-settings.tsx
@@ -28,7 +28,11 @@ export function SettingsSidebar({
       </CardHeader>
       <CardContent>
         <div className="space-y-6">
-          <AgentSelector agents={agents} setMessages={setMessages} />
+          <AgentSelector
+            agents={agents}
+            status={status}
+            setMessages={setMessages}
+          />
           <LinkAccountOwnerIdSelector
             linkedAccounts={linkedAccounts}
             status={status}

--- a/frontend/src/app/playground/setting-agent-selector.tsx
+++ b/frontend/src/app/playground/setting-agent-selector.tsx
@@ -18,10 +18,15 @@ import {
 import { BsQuestionCircle } from "react-icons/bs";
 interface AgentSelectorProps {
   agents: Agent[];
+  status: string;
   setMessages: (messages: Message[]) => void;
 }
 
-export function AgentSelector({ agents, setMessages }: AgentSelectorProps) {
+export function AgentSelector({
+  agents,
+  status,
+  setMessages,
+}: AgentSelectorProps) {
   const { selectedAgent, setSelectedAgent, setAllowedApps } = useAgentStore();
   const hasAgents = agents && agents.length > 0;
 
@@ -63,7 +68,7 @@ export function AgentSelector({ agents, setMessages }: AgentSelectorProps) {
         <Select
           value={selectedAgent}
           onValueChange={handleAgentChange}
-          disabled={true}
+          disabled={status !== "ready"}
         >
           <SelectTrigger className="w-full" aria-label="Select an agent">
             <SelectValue placeholder="Select an Agent" />

--- a/frontend/src/app/playground/setting-app-selector.tsx
+++ b/frontend/src/app/playground/setting-app-selector.tsx
@@ -39,9 +39,15 @@ export function AppMultiSelector() {
   const [apps, setApps] = useState<App[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { activeProject } = useMetaInfo();
-  const { selectedApps, setSelectedApps, allowedApps, linkedAccountOwnerId } =
-    useAgentStore();
+  const {
+    selectedApps,
+    setSelectedApps,
+    allowedApps,
+    linkedAccountOwnerId,
+    selectedAgent,
+  } = useAgentStore();
   const previousLinkedAccountOwnerIdRef = useRef<string | null>(null);
+  const previousSelectedAgentRef = useRef<string | null>(null);
 
   useEffect(() => {
     const fetchApps = async () => {
@@ -77,8 +83,12 @@ export function AppMultiSelector() {
     if (linkedAccountOwnerId !== previousLinkedAccountOwnerIdRef.current) {
       setSelectedApps([]);
     }
+    if (selectedAgent !== previousSelectedAgentRef.current) {
+      setSelectedApps([]);
+    }
     previousLinkedAccountOwnerIdRef.current = linkedAccountOwnerId;
-  }, [linkedAccountOwnerId, setSelectedApps]);
+    previousSelectedAgentRef.current = selectedAgent;
+  }, [linkedAccountOwnerId, selectedAgent, setSelectedApps]);
 
   const appList = apps.map((app) => ({
     id: app.name,

--- a/frontend/src/lib/api/util.ts
+++ b/frontend/src/lib/api/util.ts
@@ -1,6 +1,6 @@
 import { Project } from "@/lib/types/project";
 
-export function getApiKey(project: Project): string {
+export function getApiKey(project: Project, agentId?: string): string {
   if (
     !project ||
     !project.agents ||
@@ -11,6 +11,13 @@ export function getApiKey(project: Project): string {
     throw new Error(
       `No API key available in project: ${project.id} ${project.name}`,
     );
+  }
+  if (agentId) {
+    const agent = project.agents.find((agent) => agent.id === agentId);
+    if (!agent) {
+      throw new Error(`Agent ${agentId} not found in project ${project.id}`);
+    }
+    return agent.api_keys[0].key;
   }
   return project.agents[0].api_keys[0].key;
 }

--- a/frontend/src/lib/store/agent.ts
+++ b/frontend/src/lib/store/agent.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-
+import { getApiKey } from "../api/util";
+import { Project } from "../types/project";
 interface AgentState {
   selectedApps: string[];
   linkedAccountOwnerId: string;
@@ -11,9 +12,10 @@ interface AgentState {
   setAllowedApps: (apps: string[]) => void;
   setSelectedFunctions: (functions: string[]) => void;
   setSelectedAgent: (id: string) => void;
+  getApiKey: (activeProject: Project) => string;
 }
 
-export const useAgentStore = create<AgentState>()((set) => ({
+export const useAgentStore = create<AgentState>()((set, get) => ({
   selectedApps: [],
   linkedAccountOwnerId: "",
   allowedApps: [],
@@ -29,4 +31,8 @@ export const useAgentStore = create<AgentState>()((set) => ({
     set((state) => ({ ...state, selectedFunctions: functions })),
   setSelectedAgent: (id: string) =>
     set((state) => ({ ...state, selectedAgent: id })),
+  getApiKey: (activeProject: Project) => {
+    const apiKey = getApiKey(activeProject, get().selectedAgent);
+    return apiKey;
+  },
 }));


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/support-change-agent-on-frontend-1dd8378d6a47801fbcb1d4f1d7683c80?pvs=4

### 📝 Description

1. support change agent in agent playgroup
2. support getApiKey for different agent

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent selection dropdown is now enabled or disabled dynamically based on status, improving usability.
  - Selected apps are automatically cleared when the selected agent changes, ensuring consistent app selection.

- **Improvements**
  - API key retrieval is now context-aware, using both the active project and selected agent for more accurate access control.

- **Bug Fixes**
  - Resolved redundant logic in API key assignment for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->