### PR TITLE
feat: Add loading state to block rendering of main and coming soon lists

### DIFF
--- a/frontend/src/app/apps/page.tsx
+++ b/frontend/src/app/apps/page.tsx
@@ -11,10 +11,12 @@ import { useMetaInfo } from "@/components/context/metainfo";
 export default function AppStorePage() {
   const { activeProject } = useMetaInfo();
   const [apps, setApps] = useState<App[]>([]);
+  const [loading, setLoading] = useState(true);
 
   // TODO: implement pagination once we have a lot of apps
   useEffect(() => {
     async function loadApps() {
+      setLoading(true);
       try {
         const apiKey = getApiKey(activeProject);
         const apps = await getAllApps(apiKey);
@@ -22,6 +24,8 @@ export default function AppStorePage() {
         setApps(apps);
       } catch (error) {
         console.error("Error fetching apps:", error);
+      } finally {
+        setLoading(false);
       }
     }
     loadApps();
@@ -38,7 +42,7 @@ export default function AppStorePage() {
       <Separator />
 
       <div className="m-4">
-        <AppGrid apps={apps} />
+        <AppGrid apps={apps} loading={loading} />
       </div>
     </div>
   );

--- a/frontend/src/components/apps/app-grid.tsx
+++ b/frontend/src/components/apps/app-grid.tsx
@@ -12,14 +12,24 @@ import { useState } from "react";
 import { App } from "@/lib/types/app";
 import { AppCardComingSoon } from "./app-card-coming-soon";
 import comingsoon from "@/lib/comingsoon/comingsoon.json";
+import { Loader2 } from "lucide-react";
 interface AppGridProps {
   apps: App[];
+  loading: boolean;
 }
 
-export function AppGrid({ apps }: AppGridProps) {
+export function AppGrid({ apps, loading }: AppGridProps) {
   const [searchQuery, setSearchQuery] = useState("");
 
   const [selectedCategory, setSelectedCategory] = useState("all");
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-16">
+        <Loader2 className="animate-spin h-10 w-10 text-gray-500" />
+      </div>
+    );
+  }
 
   const categories = Array.from(new Set(apps.flatMap((app) => app.categories)));
 


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=1e38378d6a478017ae18effc29e33140&pm=s)

### 📝 Description

- Added `loading` state in `apps` and toggles it before and after data fetch  
- Passed the `loading` prop to the `AppGrid` component  
- Displayed a spinning `Loader2` indicator at the top of `AppGrid` when `loading` is true  

---

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/02ba3aaf-eeb2-4ec7-a5d8-5f27af35514f)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a loading spinner to the apps page, providing visual feedback while apps are being loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->