### PR TITLE
feat: update Linked Accounts page filter to use Linked Account Owner ID

### DIFF
--- a/frontend/src/app/linked-accounts/page.tsx
+++ b/frontend/src/app/linked-accounts/page.tsx
@@ -55,28 +55,24 @@ export default function LinkedAccountsPage() {
   const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[]>([]);
   const [appConfigs, setAppConfigs] = useState<AppConfig[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [selectedCategory, setSelectedCategory] = useState<string>("all");
+  const [selectedOwnerId, setSelectedOwnerId] = useState<string>("all");
   const [appsMap, setAppsMap] = useState<Record<string, App>>({});
-
-  const categories = useMemo(
+  const ownerIds = useMemo(
     () => [
-      ...new Set(Object.values(appsMap).flatMap((app) => app.categories || [])),
+      "all",
+      ...new Set(linkedAccounts.map((a) => a.linked_account_owner_id)),
     ],
-    [appsMap],
+    [linkedAccounts],
   );
 
-  const filteredLinkedAccounts = useMemo(
-    () =>
-      linkedAccounts.filter((account) => {
-        const app = appsMap[account.app_name];
-        return (
-          app &&
-          (selectedCategory === "all" ||
-            app.categories?.includes(selectedCategory))
-        );
-      }),
-    [linkedAccounts, appsMap, selectedCategory],
-  );
+  const filteredLinkedAccounts = useMemo(() => {
+    if (selectedOwnerId === "all") {
+      return linkedAccounts;
+    }
+    return linkedAccounts.filter(
+      (account) => account.linked_account_owner_id === selectedOwnerId,
+    );
+  }, [linkedAccounts, selectedOwnerId]);
 
   const loadAppMaps = useCallback(async () => {
     if (linkedAccounts.length === 0) {
@@ -212,16 +208,16 @@ export default function LinkedAccountsPage() {
           <TabsContent value="linked">
             <div className="flex items-center space-x-4 mb-6">
               <Select
-                value={selectedCategory}
-                onValueChange={setSelectedCategory}
+                value={selectedOwnerId}
+                onValueChange={setSelectedOwnerId}
               >
                 <SelectTrigger className="w-[120px]">
                   <SelectValue placeholder="ALL" />
                 </SelectTrigger>
                 <SelectContent>
-                  {["all", ...categories].map((category) => (
-                    <SelectItem key={category} value={category}>
-                      {category}
+                  {ownerIds.map((id) => (
+                    <SelectItem key={id} value={id}>
+                      {id}
                     </SelectItem>
                   ))}
                 </SelectContent>


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=1e38378d6a4780d09751ecd19c51f096&pm=s)

### 📝 Description
- Change dropdown filtering logic from App Category to Linked Account Owner ID
### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b596362e-68ee-42df-ad36-0c37b5208337)
![image](https://github.com/user-attachments/assets/3d0ea926-8b69-4c06-86d3-2d14958b8005)
![image](https://github.com/user-attachments/assets/bec4499e-4bc8-47bd-8b6d-4d84629235fa)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [✔] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
