### PR TITLE
feat: support full app logo loading in AddAccountForm

### DIFF
--- a/frontend/src/app/appconfigs/[appName]/page.tsx
+++ b/frontend/src/app/appconfigs/[appName]/page.tsx
@@ -127,6 +127,7 @@ export default function AppConfigDetailPage() {
             appInfos={[
               {
                 name: app.name,
+                logo: app.logo,
                 securitySchemes: app.security_schemes,
               },
             ]}

--- a/frontend/src/app/linked-accounts/page.tsx
+++ b/frontend/src/app/linked-accounts/page.tsx
@@ -50,6 +50,7 @@ import { EnhancedSwitch } from "@/components/ui-extensions/enhanced-switch/enhan
 import Image from "next/image";
 import { useMetaInfo } from "@/components/context/metainfo";
 import { formatToLocalTime } from "@/utils/time";
+import { getAllApps } from "@/lib/api/app";
 
 export default function LinkedAccountsPage() {
   const { activeProject } = useMetaInfo();
@@ -58,6 +59,7 @@ export default function LinkedAccountsPage() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [selectedOwnerId, setSelectedOwnerId] = useState<string>("all");
   const [appsMap, setAppsMap] = useState<Record<string, App>>({});
+  const [allApps, setAllApps] = useState<App[]>([]);
   const ownerIds = useMemo(
     () => [
       "all",
@@ -124,6 +126,14 @@ export default function LinkedAccountsPage() {
     }
   }, [activeProject]);
 
+  useEffect(() => {
+    const fetchAllApps = async () => {
+      const apiKey = getApiKey(activeProject);
+      const apps = await getAllApps(apiKey);
+      setAllApps(apps);
+    };
+    fetchAllApps();
+  }, [activeProject]);
   const refreshLinkedAccounts = useCallback(
     async (silent: boolean = false) => {
       try {
@@ -195,6 +205,7 @@ export default function LinkedAccountsPage() {
             <AddAccountForm
               appInfos={appConfigs.map((config) => ({
                 name: config.app_name,
+                logo: allApps.find((app) => app.name === config.app_name)?.logo,
                 securitySchemes: [config.security_scheme],
               }))}
               updateLinkedAccounts={() => refreshLinkedAccounts(true)}

--- a/frontend/src/components/appconfig/add-account.tsx
+++ b/frontend/src/components/appconfig/add-account.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/lib/api/linkedaccount";
 import { getApiKey } from "@/lib/api/util";
 import { useMetaInfo } from "@/components/context/metainfo";
+import Image from "next/image";
 
 const formSchema = z
   .object({
@@ -76,6 +77,7 @@ const FORM_SUBMIT_API_KEY = "apiKey";
 const FORM_SUBMIT_NO_AUTH = "noAuth";
 export interface AppInfo {
   name: string;
+  logo: string | undefined;
   securitySchemes: string[];
 }
 interface AddAccountProps {
@@ -336,7 +338,17 @@ export function AddAccountForm({
                     <SelectContent>
                       {appInfos.map((appInfo) => (
                         <SelectItem key={appInfo.name} value={appInfo.name}>
-                          {appInfo.name}
+                          <div className="flex items-center gap-2">
+                            {appInfo.logo && (
+                              <Image
+                                src={appInfo.logo}
+                                alt={appInfo.name}
+                                width={16}
+                                height={16}
+                              />
+                            )}
+                            {appInfo.name}
+                          </div>
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/frontend/src/components/appconfig/add-account.tsx
+++ b/frontend/src/components/appconfig/add-account.tsx
@@ -340,12 +340,14 @@ export function AddAccountForm({
                         <SelectItem key={appInfo.name} value={appInfo.name}>
                           <div className="flex items-center gap-2">
                             {appInfo.logo && (
-                              <Image
-                                src={appInfo.logo}
-                                alt={appInfo.name}
-                                width={16}
-                                height={16}
-                              />
+                              <div className="relative h-5 w-5 flex-shrink-0 overflow-hidden">
+                                <Image
+                                  src={appInfo.logo}
+                                  alt={appInfo.name}
+                                  fill
+                                  className="object-contain"
+                                />
+                              </div>
                             )}
                             {appInfo.name}
                           </div>


### PR DESCRIPTION
### 🏷️ Ticket

Closes #273

### 📝 Description
This PR enhances the **Add Linked Account** form by displaying app icons in the app dropdown selector.  
To achieve this:

- We now fetch **all apps** on component mount via `getAllApps`, ensuring we can display the correct logo for every configured app.
- The `AddAccountForm` receives app logo along with app name and security schemes.  

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/6bbee603-a6bc-4405-a886-07c488ea280f)
![image](https://github.com/user-attachments/assets/877ddf3f-adf9-41a0-a2de-8f4042edc3f2)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- App logos are now displayed alongside app names in the app selection dropdown when adding an account, providing a more visually informative experience.
	- App logos are included in app information throughout the linked accounts and app configuration pages, enhancing visual context for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->