### PR TITLE
add Figma OAuth2 app config

### DIFF
--- a/backend/apps/figma/app.json
+++ b/backend/apps/figma/app.json
@@ -20,7 +20,7 @@
       "scope": "current_user:read file_comments:read file_comments:write file_content:read file_dev_resources:read file_dev_resources:write file_metadata:read file_variables:read file_variables:write file_versions:read files:read library_analytics:read library_assets:read library_content:read projects:read team_library_content:read webhooks:read webhooks:write",
       "authorize_url": "https://www.figma.com/oauth",
       "access_token_url": "https://api.figma.com/v1/oauth/token",
-      "refresh_token_url": "https://api.figma.com/v1/oauth/token"
+      "refresh_token_url": "https://api.figma.com/v1/oauth/refresh"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/figma/app.json
+++ b/backend/apps/figma/app.json
@@ -10,6 +10,17 @@
       "location": "header",
       "name": "X-Figma-Token",
       "prefix": null
+    },
+    "oauth2": {
+      "location": "header",
+      "name": "Authorization",
+      "prefix": "Bearer",
+      "client_id": "{{ AIPOLABS_FIGMA_APP_CLIENT_ID }}",
+      "client_secret": "{{ AIPOLABS_FIGMA_APP_CLIENT_SECRET }}",
+      "scope": "current_user:read file_comments:read file_comments:write file_content:read file_dev_resources:read file_dev_resources:write file_metadata:read file_variables:read file_variables:write file_versions:read files:read library_analytics:read library_assets:read library_content:read projects:read team_library_content:read webhooks:read webhooks:write",
+      "authorize_url": "https://www.figma.com/oauth",
+      "access_token_url": "https://api.figma.com/v1/oauth/token",
+      "refresh_token_url": "https://api.figma.com/v1/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/Support-Figma-OAuth2-1e68378d6a4780419bd8cac3b46033c7

### 📝 Description

add OAuth2 scheme for Figma




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for OAuth2 authentication for the Figma app integration, allowing users to connect using OAuth2 in addition to API key authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->