### PR TITLE
chore: Remove hardcoded localhost:3000 from CORS settings

### DIFF
--- a/backend/aci/server/main.py
+++ b/backend/aci/server/main.py
@@ -95,7 +95,7 @@ app.add_middleware(SessionMiddleware, secret_key=config.SIGNING_KEY)
 app.add_middleware(
     CORSMiddleware,
     # TODO: remove localhost:3000 after FE contractor is done with his work
-    allow_origins=[config.DEV_PORTAL_URL, "http://localhost:3000"],
+    allow_origins=[config.DEV_PORTAL_URL],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
### 🏷️ Ticket

[Remove http://localhost:3000 from CORS
](https://www.notion.so/Remove-localhost-3000-from-CORS-1b98378d6a4780b298dec826b6ceae65?pvs=4)
### 📝 Description

This CORS setting is no longer needed. Remove it to avoid vulnerability.

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CORS policy to disallow requests from localhost:3000. Only the development portal URL is now permitted as an allowed origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->