### PR TITLE
fix: Enhance billing functionality and cleanup migration

### DIFF
--- a/backend/aci/alembic/versions/2025_05_03_1026-068b47f44d83_add_billing_related_tables.py
+++ b/backend/aci/alembic/versions/2025_05_03_1026-068b47f44d83_add_billing_related_tables.py
@@ -70,4 +70,8 @@ def downgrade() -> None:
     op.drop_table('subscriptions')
     op.drop_table('processed_stripe_events')
     op.drop_table('plans')
+
+    # Drop all the enums created by this migration
+    op.execute("DROP TYPE IF EXISTS stripe_subscription_status")
+    op.execute("DROP TYPE IF EXISTS stripe_subscription_interval")
     # ### end Alembic commands ###

--- a/backend/aci/server/routes/billing.py
+++ b/backend/aci/server/routes/billing.py
@@ -103,6 +103,8 @@ async def create_checkout_session(
             mode="subscription",
             client_reference_id=str(org_id),
             ui_mode="hosted",
+            billing_address_collection="required",
+            customer_email=user.email,
             metadata=StripeSubscriptionMetadata(
                 org_id=org_id,
                 checkout_user_id=user.user_id,

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -219,6 +219,11 @@ export default function PricingPage() {
                   variant={tier.buttonVariant}
                   disabled={subscription?.plan === tier.name}
                   onClick={async () => {
+                    if (tier.name === "enterprise") {
+                      window.location.href = "mailto:support@aipolabs.xyz";
+                      return;
+                    }
+
                     const url = await createCheckoutSession(
                       accessToken,
                       activeOrg.orgId,


### PR DESCRIPTION
### 🏷️ Ticket

[Make the Contact Us button on the pricing page clickable
](https://www.notion.so/Make-the-Contact-Us-button-on-the-pricing-page-clickable-1e88378d6a47809f89e4c3c89458a409?pvs=4)

### 📝 Description

- Added required billing address collection and customer email to the checkout session creation in the billing route.
- Updated the pricing page to redirect enterprise tier users to support via email.
- Included cleanup commands in the migration script to drop enums related to billing tables during downgrade.

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Enterprise" pricing tier now opens an email to support instead of proceeding to checkout.
- **Improvements**
  - Billing address is now required and customer email is prefilled during Stripe checkout.
- **Chores**
  - Improved database cleanup by ensuring related enum types are removed during schema downgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->