### PR TITLE
feat: mock out propelauth in local development

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,9 +51,6 @@ jobs:
     timeout-minutes: 30
     env:
       SERVER_OPENAI_API_KEY: ${{ secrets.SERVER_OPENAI_API_KEY }}
-      SERVER_PROPELAUTH_AUTH_URL: ${{ secrets.SERVER_PROPELAUTH_AUTH_URL }}
-      SERVER_PROPELAUTH_API_KEY: ${{ secrets.SERVER_PROPELAUTH_API_KEY }}
-      SERVER_SVIX_SIGNING_SECRET: ${{ secrets.SERVER_SVIX_SIGNING_SECRET }}
       CLI_OPENAI_API_KEY: ${{ secrets.CLI_OPENAI_API_KEY }}
 
     steps:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,9 +3,6 @@
 # For local development, you can reuse most of the values from the .env.example file, except for the following:
 ########################################################
 SERVER_OPENAI_API_KEY=<your_openai_api_key>
-SERVER_PROPELAUTH_AUTH_URL=<your_propel_auth_url>
-SERVER_PROPELAUTH_API_KEY=<your_propel_auth_api_key>
-SERVER_SVIX_SIGNING_SECRET=<your_svix_signing_secret>
 CLI_OPENAI_API_KEY=<your_openai_api_key_can_be_the_same_as_server_openai_api_key>
 
 
@@ -60,6 +57,11 @@ SERVER_MAX_AGENTS_PER_PROJECT=10
 # here so that the config.py won't fail
 SERVER_LOGFIRE_WRITE_TOKEN=dummy
 SERVER_LOGFIRE_READ_TOKEN=dummy
+
+# PropelAuth
+SERVER_PROPELAUTH_AUTH_URL=<your_propel_auth_url>
+SERVER_PROPELAUTH_API_KEY=<your_propel_auth_api_key>
+SERVER_SVIX_SIGNING_SECRET=<your_svix_signing_secret>
 
 # Stripe
 SERVER_STRIPE_SECRET_KEY=dummy

--- a/backend/README.md
+++ b/backend/README.md
@@ -74,20 +74,20 @@ For VS Code users, configure Ruff formatter:
    cd aci/backend
    ```
 
-2. Install dependencies and activate virtual environment:
+1. Install dependencies and activate virtual environment:
 
    ```bash
    uv sync
    source .venv/bin/activate
    ```
 
-3. Install `pre-commit` hooks:
+1. Install `pre-commit` hooks:
 
    ```bash
    pre-commit install
    ```
 
-4. Set up environment variables for **local** development:
+1. Set up environment variables for **local** development:
 
    ```bash
    cp .env.example .env.local
@@ -96,13 +96,9 @@ For VS Code users, configure Ruff formatter:
    Most sensitive variables and dummy values are already defined in `.env.example`, so you only need to set the following env vars in `.env.local`:
 
    - `SERVER_OPENAI_API_KEY`: Use your own OpenAI API key
-   - `SERVER_PROPELAUTH_AUTH_URL`: (Required if you need to develop or run the frontend) Use the auth url of your [PropelAuth Org](https://www.propelauth.com/)
-   - `SERVER_PROPELAUTH_API_KEY`: (Required if you need to develop or run the frontend) Use the API key of your PropelAuth Org. See the [PropelAuth Webhooks](#propelauth-webhooks)
-     section for how to get an API key once you have access to a PropelAuth Org.
-   - `SERVER_SVIX_SIGNING_SECRET`: (Required if you need to develop or run the frontend). If you need to develop the frontend, complete the [PropelAuth Webhooks](#propelauth-webhooks) section before moving on.
    - `CLI_OPENAI_API_KEY`: Use your own OpenAI API key (can be the same as `SERVER_OPENAI_API_KEY`)
 
-5. Start services with Docker Compose:
+1. Start services with Docker Compose:
 
    ```bash
    docker compose up --build
@@ -114,36 +110,40 @@ For VS Code users, configure Ruff formatter:
    - `aws`: LocalStack for mocking AWS services
    - `runner`: Container for running commands like pytest, cli commands or scripts
 
-6. (Optional) Seed the database with sample data:
+1. Seed the database with sample data:
 
    ```bash
    docker compose exec runner ./scripts/seed_db.sh
    ```
 
-7. (Optional) Connect to the database using a GUI client (e.g., `DBeaver`)
+   The script will output an API key that you can use on the swagger UI or sending HTTP
+   requests to the local backend server directly.
+
+1. (Optional) Connect to the database using a GUI client (e.g., `DBeaver`)
 
    - Parameters for the db connection can be found in the `.env.local` file you created in step 4.
 
-8. Create a random API key for local development (step 6 also creates a random API key when you run the seed db script):
-
-   ```bash
-   docker compose exec runner python -m aci.cli create-random-api-key --visibility-access public
-   ```
-
-9. Access the API documentation at:
+1. Access the API documentation at:
 
    ```bash
    http://localhost:8000/v1/notforhuman-docs
    ```
 
-10. (Optional) If you are developing the dev portal, follow the instructions on [frontend README](../frontend/README.md) to start the dev portal.
+1. (Optional) If you are developing the dev portal, follow the instructions on [frontend README](../frontend/README.md) to start the dev portal.
 
-11. (Optional) If you are developing Stripe related billing features, follow the
+1. (Optional) If you are developing Stripe related billing features, follow the
     [Stripe Webhooks](#stripe-webhooks) section.
 
 ### Running Tests
 
-Ensure the `db` service is running and the database is empty (in case you have seeded the db in the previous steps) before running tests:
+Ensure the `db` service is running and the database is empty (in case you have seeded
+the db in `step 6`) before running tests.
+
+More specifically, if you have run the `seed_db.sh` script already, you need to bring
+down docker compose and bring it up again without running the `seed_db.sh` script this
+time.
+
+Then you can run the test in the `runner` container:
 
 ```bash
 docker compose exec runner pytest
@@ -188,10 +188,16 @@ When making changes to database models:
 ## PropelAuth Webhooks
 
 > [!NOTE]
-> This is only needed if you need to develop or run the dev portal.
+> This is only needed if you need to develop PropelAuth related features.
 
 If you are developing the dev portal, you would need a real `user` and `org` in the
 PropelAuth test environment as well as a default `project` and `agent` in your local db.
+
+You would need to replace a few dummy values with real values in `.env.local`:
+
+- `SERVER_PROPELAUTH_AUTH_URL`
+- `SERVER_PROPELAUTH_API_KEY`
+- `SERVER_SVIX_SIGNING_SECRET`
 
 Follow the steps here to set up the webhooks so that when you sign up on the PropelAuth
 test environment, PropelAuth will notify your local server to create an org in the
@@ -204,7 +210,8 @@ the local db.
    - Copy your public endpoint you just exposed from previous step and create a new endpoint in the [ngrok dashboard](https://dashboard.ngrok.com/endpoints) (e.g. <https://7c4c-2a06-5904-1e06-6a00-ddc6-68ce-ffae-8783.ngrok-free.app>)
 
 2. Configure PropelAuth:
-   - Go to your PropelAuth Org [dashboard](https://app.propelauth.com/proj/1b327933-ffbf-4a36-bd05-76cd896b0d56)
+   - Go to your PropelAuth Org [dashboard](https://app.propelauth.com/proj/1b327933-ffbf-4a36-bd05-76cd896b0d56) (the link here is ours, you would need your own)
+   - In the Frontend Integrations tab, you can find an Auth URL, copy that URL and use it to replace the dummy value of `SERVER_PROPELAUTH_AUTH_URL` in `.env.local`
    - Go to the **Users** and **Organizations** tabs, delete your previously created user and organization. (Note: only delete the user and org you created previously)
      ![delete user](./images/delete-user.png)
      ![delete org](./images/delete-org.png)

--- a/backend/aci/cli/commands/create_random_api_key.py
+++ b/backend/aci/cli/commands/create_random_api_key.py
@@ -30,13 +30,20 @@ console = Console()
     type=Visibility,
     help="visibility access of the project that the api key belongs to, either 'public' or 'private'",
 )
+@click.option(
+    "--org-id",
+    "org_id",
+    required=False,
+    type=uuid.UUID,
+    help="organization id",
+)
 @click.command()
-def create_random_api_key(visibility_access: Visibility) -> str:
+def create_random_api_key(visibility_access: Visibility, org_id: uuid.UUID | None) -> str:
     """Create a random test api key for local development."""
-    return create_random_api_key_helper(visibility_access)
+    return create_random_api_key_helper(visibility_access, org_id)
 
 
-def create_random_api_key_helper(visibility_access: Visibility) -> str:
+def create_random_api_key_helper(visibility_access: Visibility, org_id: uuid.UUID | None) -> str:
     # can not do dry run because of the dependencies
     skip_dry_run = True
 
@@ -44,7 +51,7 @@ def create_random_api_key_helper(visibility_access: Visibility) -> str:
 
     project_id = create_project.create_project_helper(
         name=f"Test Project {random_id}",
-        org_id=uuid.uuid4(),
+        org_id=org_id or uuid.uuid4(),
         visibility_access=visibility_access,
         skip_dry_run=skip_dry_run,
     )

--- a/backend/compose.ci.yml
+++ b/backend/compose.ci.yml
@@ -4,14 +4,10 @@ services:
   server:
     environment:
       - SERVER_OPENAI_API_KEY=${SERVER_OPENAI_API_KEY?}
-      - SERVER_PROPELAUTH_AUTH_URL=${SERVER_PROPELAUTH_AUTH_URL?}
-      - SERVER_PROPELAUTH_API_KEY=${SERVER_PROPELAUTH_API_KEY?}
       - CLI_OPENAI_API_KEY=${CLI_OPENAI_API_KEY?}
   runner:
     environment:
       - SERVER_OPENAI_API_KEY=${SERVER_OPENAI_API_KEY?}
-      - SERVER_PROPELAUTH_AUTH_URL=${SERVER_PROPELAUTH_AUTH_URL?}
-      - SERVER_PROPELAUTH_API_KEY=${SERVER_PROPELAUTH_API_KEY?}
       - CLI_OPENAI_API_KEY=${CLI_OPENAI_API_KEY?}
     command: >
       /bin/sh -c "alembic upgrade head && uv run pytest"

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -27,6 +27,17 @@ services:
     volumes:
       - ./scripts/create-kms-encryption-key.sh:/etc/localstack/init/ready.d/create-kms-encryption-key.sh
 
+  propelauth_mock:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    ports:
+      - "12800:12800"
+    working_dir: /workdir
+    volumes:
+      - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
+    command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800 --reload
+
   server:
     build:
       context: .
@@ -43,6 +54,8 @@ services:
     volumes:
       - ./aci/server:/workdir/aci/server
       - ./aci/common:/workdir/aci/common
+      # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     ports:
       - "8000:8000"
     # this overrides the default CMD specified in the Dockerfile, use this for local development

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -81,6 +81,8 @@ services:
       - ./apps:/workdir/apps
       - ./scripts:/workdir/scripts
       - ./alembic.ini:/workdir/alembic.ini
+      # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     command: >
       /bin/sh -c "alembic upgrade head && tail -f /dev/null"
     depends_on:

--- a/backend/mock/propelauth_fastapi_mock.py
+++ b/backend/mock/propelauth_fastapi_mock.py
@@ -1,0 +1,596 @@
+# type: ignore
+
+from typing import Any
+
+import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from propelauth_py import (
+    Auth,
+    SamlIdpMetadata,
+    StepUpMfaGrantType,
+    StepUpMfaVerifyTotpResponse,
+    TokenVerificationMetadata,
+)
+from propelauth_py.api import (
+    OrgQueryOrderBy,
+    UserQueryOrderBy,
+)
+from propelauth_py.errors import ForbiddenException, UnauthorizedException
+from propelauth_py.user import OrgMemberInfo, User
+
+_security = HTTPBearer(auto_error=False)
+
+
+def _require_org_member_wrapper(auth, debug_mode: bool):
+    def require_org_member(user: User, required_org_id: str):
+        try:
+            return auth.validate_org_access_and_get_org(user, required_org_id)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, debug_mode)
+
+    return require_org_member
+
+
+def _require_org_member_with_minimum_role_wrapper(auth, debug_mode: bool):
+    def require_org_member_with_minimum_role(
+        user: User, required_org_id: str, minimum_required_role: str
+    ):
+        try:
+            return auth.validate_minimum_org_role_and_get_org(
+                user, required_org_id, minimum_required_role
+            )
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, debug_mode)
+
+    return require_org_member_with_minimum_role
+
+
+def _require_org_member_with_exact_role_wrapper(auth, debug_mode: bool):
+    def require_org_member_with_exact_role(user: User, required_org_id: str, role: str):
+        try:
+            return auth.validate_exact_org_role_and_get_org(user, required_org_id, role)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, debug_mode)
+
+    return require_org_member_with_exact_role
+
+
+def _require_org_member_with_permission_wrapper(auth, debug_mode: bool):
+    def require_org_member_with_permission(user: User, required_org_id: str, permission: str):
+        try:
+            return auth.validate_permission_and_get_org(user, required_org_id, permission)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, debug_mode)
+
+    return require_org_member_with_permission
+
+
+def _require_org_member_with_all_permissions_wrapper(auth, debug_mode: bool):
+    def require_org_member_with_all_permissions(
+        user: User, required_org_id: str, permissions: list[str]
+    ):
+        try:
+            return auth.validate_all_permissions_and_get_org(user, required_org_id, permissions)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, debug_mode)
+
+    return require_org_member_with_all_permissions
+
+
+def _handle_forbidden_exception(e: ForbiddenException, debug_mode: bool):
+    if debug_mode:
+        raise HTTPException(status_code=403, detail=e.message)
+    else:
+        raise HTTPException(status_code=403)
+
+
+class FastAPIAuth:
+    def __init__(
+        self,
+        auth_url: str,
+        integration_api_key: str,
+        token_verification_metadata: TokenVerificationMetadata | None,
+        debug_mode: bool,
+    ):
+        self.auth_url = auth_url
+        self.integration_api_key = integration_api_key
+        self.token_verification_metadata = token_verification_metadata
+        self.debug_mode = debug_mode
+        self.auth = Auth(auth_url, integration_api_key, None)
+
+    def require_user(self, credentials: HTTPAuthorizationCredentials = Depends(_security)):
+        try:
+            try:
+                decoded_payload = jwt.decode(
+                    credentials.credentials,
+                    options={"verify_signature": False, "verify_aud": False},
+                )
+            except jwt.DecodeError as e:
+                print(f"Error decoding JWT: {e}")
+
+            # Use the decoded payload to populate the User object
+            user_id = decoded_payload.get("user_id")
+            email = decoded_payload.get("email")
+            org_info_dict = decoded_payload.get("org_id_to_org_member_info", {})
+            login_method = decoded_payload.get("login_method", {})
+
+            org_id_to_org_member_info = {}
+            for org_id, org_data in org_info_dict.items():
+                org_id_to_org_member_info[org_id] = OrgMemberInfo(
+                    org_id=org_data.get("org_id"),
+                    org_name=org_data.get("org_name"),
+                    url_safe_org_name=org_data.get("url_safe_org_name"),
+                    org_metadata=org_data.get("org_metadata", {}),
+                    user_assigned_role=org_data.get("user_role"),  # Note: key is 'user_role' in JWT
+                    user_inherited_roles_plus_current_role=org_data.get(
+                        "inherited_user_roles_plus_current_role", []
+                    ),
+                    org_role_structure=org_data.get("org_role_structure"),
+                    assigned_additional_roles=org_data.get(
+                        "additional_roles", []
+                    ),  # Note: key is 'additional_roles' in JWT
+                    user_permissions=org_data.get("user_permissions", []),
+                )
+
+            return User(
+                user_id=user_id,
+                email=email,
+                org_id_to_org_member_info=org_id_to_org_member_info,
+                login_method=login_method,
+            )
+        except UnauthorizedException as e:
+            if self.debug_mode:
+                raise HTTPException(status_code=401, detail=e.message)
+            else:
+                raise HTTPException(status_code=401)
+
+    def optional_user(self, credentials: HTTPAuthorizationCredentials = Depends(_security)):
+        if credentials is None:
+            return None
+
+        try:
+            authorization_header = credentials.scheme + " " + credentials.credentials
+            user = self.auth.validate_access_token_and_get_user(authorization_header)
+            return user
+        except UnauthorizedException:
+            return None
+
+    def require_org_member(self, user: User, required_org_id: str):
+        try:
+            return self.auth.validate_org_access_and_get_org(user, required_org_id)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, self.debug_mode)
+
+    def require_org_member_with_minimum_role(
+        self, user: User, required_org_id: str, minimum_required_role: str
+    ):
+        try:
+            return self.auth.validate_minimum_org_role_and_get_org(
+                user, required_org_id, minimum_required_role
+            )
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, self.debug_mode)
+
+    def require_org_member_with_exact_role(self, user: User, required_org_id: str, role: str):
+        try:
+            return self.auth.validate_exact_org_role_and_get_org(user, required_org_id, role)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, self.debug_mode)
+
+    def require_org_member_with_permission(self, user: User, required_org_id: str, permission: str):
+        try:
+            return self.auth.validate_permission_and_get_org(user, required_org_id, permission)
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, self.debug_mode)
+
+    def require_org_member_with_all_permissions(
+        self, user: User, required_org_id: str, permissions: list[str]
+    ):
+        try:
+            return self.auth.validate_all_permissions_and_get_org(
+                user, required_org_id, permissions
+            )
+        except ForbiddenException as e:
+            _handle_forbidden_exception(e, self.debug_mode)
+
+    def validate_access_token_and_get_user(self, authorization_header: str) -> User:
+        return self.auth.validate_access_token_and_get_user(
+            authorization_header=authorization_header
+        )
+
+    def fetch_user_metadata_by_user_id(self, user_id: str, include_orgs: bool = False):
+        return self.auth.fetch_user_metadata_by_user_id(user_id, include_orgs)
+
+    def fetch_user_metadata_by_email(self, email: str, include_orgs: bool = False):
+        return self.auth.fetch_user_metadata_by_email(email, include_orgs)
+
+    def fetch_user_metadata_by_username(self, username: str, include_orgs: bool = False):
+        return self.auth.fetch_user_metadata_by_username(username, include_orgs)
+
+    def fetch_user_signup_query_params_by_user_id(self, user_id: str):
+        return self.auth.fetch_user_signup_query_params_by_user_id(user_id)
+
+    def fetch_batch_user_metadata_by_user_ids(
+        self, user_ids: list[str], include_orgs: bool = False
+    ):
+        return self.auth.fetch_batch_user_metadata_by_user_ids(user_ids, include_orgs)
+
+    def fetch_batch_user_metadata_by_emails(self, emails: list[str], include_orgs: bool = False):
+        return self.auth.fetch_batch_user_metadata_by_emails(emails, include_orgs)
+
+    def fetch_batch_user_metadata_by_usernames(
+        self, usernames: list[str], include_orgs: bool = False
+    ):
+        return self.auth.fetch_batch_user_metadata_by_usernames(usernames, include_orgs)
+
+    def fetch_org(self, org_id: str):
+        return self.auth.fetch_org(org_id)
+
+    def fetch_org_by_query(
+        self,
+        page_size: int = 10,
+        page_number: int = 0,
+        order_by: OrgQueryOrderBy = OrgQueryOrderBy.CREATED_AT_ASC,
+        name: str | None = None,
+        legacy_org_id: str | None = None,
+        domain: str | None = None,
+    ):
+        return self.auth.fetch_org_by_query(
+            page_size, page_number, order_by, name, legacy_org_id, domain
+        )
+
+    def fetch_custom_role_mappings(self):
+        return self.auth.fetch_custom_role_mappings()
+
+    def fetch_pending_invites(
+        self, page_number: int = 0, page_size: int = 10, org_id: str | None = None
+    ):
+        return self.auth.fetch_pending_invites(page_number, page_size, org_id)
+
+    def fetch_users_by_query(
+        self,
+        page_size: int = 10,
+        page_number: int = 0,
+        order_by: UserQueryOrderBy = UserQueryOrderBy.CREATED_AT_ASC,
+        email_or_username: str | None = None,
+        include_orgs: bool = False,
+        legacy_user_id: str | None = None,
+    ):
+        return self.auth.fetch_users_by_query(
+            page_size, page_number, order_by, email_or_username, include_orgs, legacy_user_id
+        )
+
+    def fetch_users_in_org(
+        self,
+        org_id: str,
+        page_size: int = 10,
+        page_number: int = 0,
+        include_orgs: bool = False,
+        role: str | None = None,
+    ):
+        return self.auth.fetch_users_in_org(org_id, page_size, page_number, include_orgs, role)
+
+    def create_user(
+        self,
+        email: str,
+        email_confirmed: bool = False,
+        send_email_to_confirm_email_address: bool = True,
+        ask_user_to_update_password_on_login: bool = False,
+        password: str | None = None,
+        username: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        properties: dict[str, Any] | None = None,
+        ignore_domain_restrictions: bool = False,
+    ):
+        return self.auth.create_user(
+            email,
+            email_confirmed,
+            send_email_to_confirm_email_address,
+            ask_user_to_update_password_on_login,
+            password,
+            username,
+            first_name,
+            last_name,
+            properties,
+            ignore_domain_restrictions,
+        )
+
+    def invite_user_to_org(
+        self, email: str, org_id: str, role: str, additional_roles: list[str] = []
+    ):
+        return self.auth.invite_user_to_org(email, org_id, role, additional_roles)
+
+    def resend_email_confirmation(self, user_id: str):
+        return self.auth.resend_email_confirmation(user_id)
+
+    def logout_all_user_sessions(self, user_id: str):
+        return self.auth.logout_all_user_sessions(user_id)
+
+    def update_user_email(self, user_id: str, new_email: str, require_email_confirmation: bool):
+        return self.auth.update_user_email(user_id, new_email, require_email_confirmation)
+
+    def update_user_metadata(
+        self,
+        user_id: str,
+        username: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        properties: dict[str, Any] | None = None,
+        picture_url: str | None = None,
+        update_password_required: bool | None = None,
+        legacy_user_id: str | None = None,
+    ):
+        return self.auth.update_user_metadata(
+            user_id,
+            username,
+            first_name,
+            last_name,
+            metadata,
+            properties,
+            picture_url,
+            update_password_required,
+            legacy_user_id,
+        )
+
+    def clear_user_password(self, user_id: str):
+        return self.auth.clear_user_password(user_id)
+
+    def update_user_password(
+        self, user_id: str, password: str, ask_user_to_update_password_on_login: bool = False
+    ):
+        return self.auth.update_user_password(
+            user_id, password, ask_user_to_update_password_on_login
+        )
+
+    def create_magic_link(
+        self,
+        email: str,
+        redirect_to_url: str | None = None,
+        expires_in_hours: str | None = None,
+        create_new_user_if_one_doesnt_exist: bool | None = None,
+        user_signup_query_parameters: dict[str, Any] | None = None,
+    ):
+        return self.auth.create_magic_link(
+            email,
+            redirect_to_url,
+            expires_in_hours,
+            create_new_user_if_one_doesnt_exist,
+            user_signup_query_parameters,
+        )
+
+    def create_access_token(
+        self, user_id: str, duration_in_minutes: int, active_org_id: str | None = None
+    ):
+        return self.auth.create_access_token(user_id, duration_in_minutes, active_org_id)
+
+    def migrate_user_from_external_source(
+        self,
+        email: str,
+        email_confirmed: bool,
+        existing_user_id: str | None = None,
+        existing_password_hash: str | None = None,
+        existing_mfa_base32_encoded_secret: str | None = None,
+        ask_user_to_update_password_on_login: bool = False,
+        enabled: bool | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        username: str | None = None,
+        picture_url: str | None = None,
+        properties: dict[str, Any] | None = None,
+    ):
+        return self.auth.migrate_user_from_external_source(
+            email,
+            email_confirmed,
+            existing_user_id,
+            existing_password_hash,
+            existing_mfa_base32_encoded_secret,
+            ask_user_to_update_password_on_login,
+            enabled,
+            first_name,
+            last_name,
+            username,
+            picture_url,
+            properties,
+        )
+
+    def migrate_user_password(
+        self,
+        user_id: str,
+        password_hash: str,
+    ):
+        return self.auth.migrate_user_password(user_id, password_hash)
+
+    def create_org(
+        self,
+        name: str,
+        enable_auto_joining_by_domain: bool = False,
+        members_must_have_matching_domain: bool = False,
+        domain: str | None = None,
+        max_users: str | None = None,
+        custom_role_mapping_name: str | None = None,
+        legacy_org_id: str | None = None,
+    ):
+        return self.auth.create_org(
+            name,
+            enable_auto_joining_by_domain,
+            members_must_have_matching_domain,
+            domain,
+            max_users,
+            custom_role_mapping_name,
+            legacy_org_id,
+        )
+
+    def update_org_metadata(
+        self,
+        org_id: str,
+        name: str | None = None,
+        can_setup_saml: bool | None = None,
+        metadata: dict[str, Any] | None = None,
+        max_users: str | None = None,
+        can_join_on_email_domain_match: bool | None = None,
+        members_must_have_email_domain_match: bool | None = None,
+        domain: str | None = None,
+        require_2fa_by: str | None = None,
+        extra_domains: list[str] | None = None,
+    ):
+        return self.auth.update_org_metadata(
+            org_id,
+            name,
+            can_setup_saml,
+            metadata,
+            max_users,
+            can_join_on_email_domain_match,
+            members_must_have_email_domain_match,
+            domain,
+            require_2fa_by,
+            extra_domains,
+        )
+
+    def subscribe_org_to_role_mapping(self, org_id: str, custom_role_mapping_name: str):
+        return self.auth.subscribe_org_to_role_mapping(org_id, custom_role_mapping_name)
+
+    def delete_org(self, org_id: str):
+        return self.auth.delete_org(org_id)
+
+    def revoke_pending_org_invite(self, org_id: str, invitee_email: str):
+        return self.auth.revoke_pending_org_invite(org_id, invitee_email)
+
+    def add_user_to_org(
+        self, user_id: str, org_id: str, role: str, additional_roles: list[str] = []
+    ):
+        return self.auth.add_user_to_org(user_id, org_id, role, additional_roles)
+
+    def remove_user_from_org(self, user_id: str, org_id: str):
+        return self.auth.remove_user_from_org(user_id, org_id)
+
+    def change_user_role_in_org(
+        self, user_id: str, org_id: str, role: str, additional_roles: list[str] = []
+    ):
+        return self.auth.change_user_role_in_org(user_id, org_id, role, additional_roles)
+
+    def delete_user(self, user_id: str):
+        return self.auth.delete_user(user_id)
+
+    def disable_user(self, user_id: str):
+        return self.auth.disable_user(user_id)
+
+    def enable_user(self, user_id: str):
+        return self.auth.enable_user(user_id)
+
+    def disable_user_2fa(self, user_id: str):
+        return self.auth.disable_user_2fa(user_id)
+
+    def enable_user_can_create_orgs(self, user_id: str):
+        return self.auth.enable_user_can_create_orgs(user_id)
+
+    def disable_user_can_create_orgs(self, user_id: str):
+        return self.auth.disable_user_can_create_orgs(user_id)
+
+    def allow_org_to_setup_saml_connection(self, org_id: str):
+        return self.auth.allow_org_to_setup_saml_connection(org_id)
+
+    def disallow_org_to_setup_saml_connection(self, org_id: str):
+        return self.auth.disallow_org_to_setup_saml_connection(org_id)
+
+    def fetch_api_key(self, api_key_id: str):
+        return self.auth.fetch_api_key(api_key_id)
+
+    def fetch_current_api_keys(
+        self,
+        org_id: str | None = None,
+        user_id: str | None = None,
+        user_email: str | None = None,
+        page_size: int | None = None,
+        page_number: int | None = None,
+        api_key_type: str | None = None,
+    ):
+        return self.auth.fetch_current_api_keys(
+            org_id, user_id, user_email, page_size, page_number, api_key_type
+        )
+
+    def fetch_archived_api_keys(
+        self,
+        org_id: str | None = None,
+        user_id: str | None = None,
+        user_email: str | None = None,
+        page_size: int | None = None,
+        page_number: int | None = None,
+        api_key_type: str | None = None,
+    ):
+        return self.auth.fetch_archived_api_keys(
+            org_id, user_id, user_email, page_size, page_number, api_key_type
+        )
+
+    def create_api_key(
+        self,
+        org_id: str | None = None,
+        user_id: str | None = None,
+        expires_at_seconds: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        return self.auth.create_api_key(org_id, user_id, expires_at_seconds, metadata)
+
+    def update_api_key(
+        self,
+        api_key_id: str,
+        expires_at_seconds: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        return self.auth.update_api_key(api_key_id, expires_at_seconds, metadata)
+
+    def delete_api_key(self, api_key_id: str):
+        return self.auth.delete_api_key(api_key_id)
+
+    def validate_personal_api_key(self, api_key_token: str):
+        return self.auth.validate_personal_api_key(api_key_token)
+
+    def validate_org_api_key(self, api_key_token: str):
+        return self.auth.validate_org_api_key(api_key_token)
+
+    def validate_api_key(self, api_key_token: str):
+        return self.auth.validate_api_key(api_key_token)
+
+    def fetch_saml_sp_metadata(self, org_id: str):
+        return self.auth.fetch_saml_sp_metadata(org_id)
+
+    def set_saml_idp_metadata(self, org_id: str, saml_idp_metadata: SamlIdpMetadata):
+        return self.auth.set_saml_idp_metadata(org_id=org_id, saml_idp_metadata=saml_idp_metadata)
+
+    def saml_go_live(self, org_id: str):
+        return self.auth.saml_go_live(org_id)
+
+    def delete_saml_connection(self, org_id: str):
+        return self.auth.delete_saml_connection(org_id)
+
+    def verify_step_up_totp_challenge(
+        self,
+        action_type: str,
+        user_id: str,
+        code: str,
+        grant_type: StepUpMfaGrantType,
+        valid_for_seconds: int,
+    ) -> StepUpMfaVerifyTotpResponse:
+        return self.auth.verify_step_up_totp_challenge(
+            action_type, user_id, code, grant_type, valid_for_seconds
+        )
+
+    def verify_step_up_grant(self, action_type: str, user_id: str, grant: str) -> bool:
+        return self.auth.verify_step_up_grant(action_type, user_id, grant)
+
+
+def init_auth(
+    auth_url: str,
+    api_key: str,
+    token_verification_metadata: TokenVerificationMetadata | None = None,
+    debug_mode=False,
+) -> FastAPIAuth:
+    """Fetches metadata required to validate access tokens and returns auth decorators and utilities"""
+    return FastAPIAuth(
+        auth_url=auth_url,
+        integration_api_key=api_key,
+        token_verification_metadata=token_verification_metadata,
+        debug_mode=debug_mode,
+    )

--- a/backend/mock/propelauth_fastapi_mock.py
+++ b/backend/mock/propelauth_fastapi_mock.py
@@ -1,4 +1,5 @@
 # type: ignore
+# ruff: noqa
 
 from typing import Any
 

--- a/backend/mock/propelauth_mock_server.py
+++ b/backend/mock/propelauth_mock_server.py
@@ -1,0 +1,61 @@
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/api/v1/refresh_token")
+async def refresh_token() -> dict:
+    return {
+        "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjA2YzZmZjc1LWVkODMtNDkzOC1iZWEzLTAzNDExYjc0MDc2ZSJ9.eyJzdWIiOiJlNTA4NzBkMi05ZGNkLTQ0ZmUtYTI3My0xYjljYzFlOTgyZGUiLCJpYXQiOjE3NDYyNzI5NDAsImV4cCI6MTc0NjI3NDc0MCwidXNlcl9pZCI6ImU1MDg3MGQyLTlkY2QtNDRmZS1hMjczLTFiOWNjMWU5ODJkZSIsImlzcyI6Imh0dHBzOi8vODM2Nzg3OC5wcm9wZWxhdXRodGVzdC5jb20iLCJlbWFpbCI6InppeHVhbnpoYW5nLnhAZ21haWwuY29tIiwib3JnX2lkX3RvX29yZ19tZW1iZXJfaW5mbyI6eyIxMDdlMDZkYS1lODU3LTQ4NjQtYmMxZC00YWRjYmEwMmFiNzYiOnsib3JnX2lkIjoiMTA3ZTA2ZGEtZTg1Ny00ODY0LWJjMWQtNGFkY2JhMDJhYjc2Iiwib3JnX25hbWUiOiJQZXJzb25hbCBmYTBIMW0iLCJ1cmxfc2FmZV9vcmdfbmFtZSI6InBlcnNvbmFsLWZhMGgxbSIsIm9yZ19tZXRhZGF0YSI6eyJwZXJzb25hbCI6dHJ1ZX0sInVzZXJfcm9sZSI6Ik93bmVyIiwiaW5oZXJpdGVkX3VzZXJfcm9sZXNfcGx1c19jdXJyZW50X3JvbGUiOlsiT3duZXIiLCJBZG1pbiIsIk1lbWJlciJdLCJvcmdfcm9sZV9zdHJ1Y3R1cmUiOiJzaW5nbGVfcm9sZV9pbl9oaWVyYXJjaHkiLCJhZGRpdGlvbmFsX3JvbGVzIjpbXSwidXNlcl9wZXJtaXNzaW9ucyI6WyJwcm9wZWxhdXRoOjpjYW5faW52aXRlIiwicHJvcGVsYXV0aDo6Y2FuX2NoYW5nZV9yb2xlcyIsInByb3BlbGF1dGg6OmNhbl9yZW1vdmVfdXNlcnMiLCJwcm9wZWxhdXRoOjpjYW5fc2V0dXBfc2FtbCIsInByb3BlbGF1dGg6OmNhbl9tYW5hZ2VfYXBpX2tleXMiLCJwcm9wZWxhdXRoOjpjYW5fZWRpdF9vcmdfYWNjZXNzIiwicHJvcGVsYXV0aDo6Y2FuX3VwZGF0ZV9vcmdfbWV0YWRhdGEiLCJwcm9wZWxhdXRoOjpjYW5fdmlld19vdGhlcl9tZW1iZXJzIiwicHJvcGVsYXV0aDo6Y2FuX2RlbGV0ZV9vcmciXX19LCJsb2dpbl9tZXRob2QiOnsibG9naW5fbWV0aG9kIjoic29jaWFsX3NzbyIsInByb3ZpZGVyIjoiR29vZ2xlIn19.eElE7YM62NOx29rHKtbDE8Z9Wd71QSCjZ5WAA4Xxd1vYru4PFrj2gDWqZSBGEAWZ7Un1O35CcYkaDou3fNulcuf43-xIeLXv_pZnw1Z7P1ZDb--e7FqgT_K_J_Ew5Nb4qwBo4csXQIw-tyK-kNbkFIqmK50WVaHUww5geUXmNx6NoiAilWCARQ5NH95fvAvC1uwBfuZw-2WoJxJQpZn5aPy3RbsYauoOG_uxFNg32mH3Oqdy1UJmj6-ZJPezi0OlO1fDIafNRiUBKk4Uidxom8oWcOSlwawARNiNxFIEhieMiv0M-HMUz8wTgxqBJJUNRVQislyTNAjuCpiapTwNhw",
+        "expires_at_seconds": 174274740,
+        "org_id_to_org_member_info": {
+            "107e06da-e857-4864-bc1d-4adcba02ab76": {
+                "org_id": "107e06da-e857-4864-bc1d-4adcba02ab76",
+                "org_name": "Personal fa0H1m",
+                "url_safe_org_name": "personal-fa0h1m",
+                "org_metadata": {"personal": True},
+                "user_role": "Owner",
+                "inherited_user_roles_plus_current_role": ["Owner", "Admin", "Member"],
+                "org_role_structure": "single_role_in_hierarchy",
+                "additional_roles": [],
+                "user_permissions": [
+                    "propelauth::can_invite",
+                    "propelauth::can_change_roles",
+                    "propelauth::can_remove_users",
+                    "propelauth::can_setup_saml",
+                    "propelauth::can_manage_api_keys",
+                    "propelauth::can_edit_org_access",
+                    "propelauth::can_update_org_metadata",
+                    "propelauth::can_view_other_members",
+                    "propelauth::can_delete_org",
+                ],
+            }
+        },
+        "user": {
+            "user_id": "e50870d2-9dcd-44fe-a273-1b9cc1e982de",
+            "email": "testuser@aipolabs.xyz",
+            "email_confirmed": True,
+            "has_password": False,
+            "first_name": "Test",
+            "last_name": "User",
+            "picture_url": "",
+            "properties": {},
+            "metadata": None,
+            "locked": False,
+            "enabled": True,
+            "mfa_enabled": False,
+            "can_create_orgs": False,
+            "created_at": 1746268241,
+            "last_active_at": 1746272886,
+            "update_password_required": False,
+        },
+    }

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -64,7 +64,8 @@ parse_arguments() {
 # Call our argument parser
 parse_arguments "$@"
 
-# Seed the database with a user resource
+# Seed the database with a default project and a default agent. The command will
+# output the API key of that agent that can be used in the swagger UI.
 if [ "$SEED_USER" = true ]; then
   python -m aci.cli.aci create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
 fi

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -64,6 +64,11 @@ parse_arguments() {
 # Call our argument parser
 parse_arguments "$@"
 
+# Seed the database with a user resource
+if [ "$SEED_USER" = true ]; then
+  python -m aci.cli.aci create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
+fi
+
 # Seed the database with Plans
 if [ "$SEED_PLANS" = true ]; then
   python -m aci.cli populate-subscription-plans --skip-dry-run
@@ -96,9 +101,4 @@ if [ "$SEED_FUNCTIONS" = true ]; then
       --functions-file "$functions_file" \
       --skip-dry-run
   done
-fi
-
-# Seed the database with a user resource
-if [ "$SEED_USER" = true ]; then
-  python -m aci.cli create-random-api-key --visibility-access public
 fi

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_DEV_PORTAL_URL=http://localhost:3000
 NEXT_PUBLIC_ENVIRONMENT=local
-NEXT_PUBLIC_AUTH_URL=https://8367878.propelauthtest.com
+NEXT_PUBLIC_AUTH_URL=http://localhost:12800


### PR DESCRIPTION

### 🏷️ Ticket

[Simplify Local Development(Auth)
](https://www.notion.so/Simplify-Local-Development-Auth-1e48378d6a4780079c70f4b7c08226e7?pvs=4)
### 📝 Description

- Introduced a new Docker service for the propelauth mock server to facilitate local development.
- Updated the create_random_api_key command to accept an optional organization ID, allowing for more flexible API key generation.
- Modified the seed_db.sh script to include seeding a user resource with a specified organization ID.
- Adjusted the .env.example file to point to the local mock server for authentication during development.


### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mock authentication server and mock authentication utilities to support local development and testing without real token validation.
- **Chores**
  - Updated Docker Compose setup to include the mock authentication service and override authentication modules for development.
  - Adjusted environment variable examples and configuration files for improved clarity and local development compatibility.
  - Enhanced database seeding script to support specifying an organization ID when creating user API keys.
- **Documentation**
  - Improved organization and grouping of environment variables in example files.
  - Refined backend setup instructions for clearer environment variable usage and testing procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->