### PR TITLE
Replace app title link with 'Go to App' button on configuration page

### DIFF
--- a/frontend/src/app/appconfigs/[appName]/page.tsx
+++ b/frontend/src/app/appconfigs/[appName]/page.tsx
@@ -271,24 +271,31 @@ export default function AppConfigDetailPage() {
             )}
           </div>
           <div>
-            <Link href={`/apps/${app?.name}`}>
-              <h1 className="text-2xl font-semibold">{app?.display_name}</h1>
-            </Link>
+            <h1 className="text-2xl font-semibold">{app?.display_name}</h1>
             <IdDisplay id={app?.name ?? ""} />
           </div>
         </div>
-        {app && (
-          <AddAccountForm
-            appInfos={[
-              {
-                name: app.name,
-                logo: app.logo,
-                securitySchemes: app.security_schemes,
-              },
-            ]}
-            updateLinkedAccounts={refreshLinkedAccounts}
-          />
-        )}
+        <div className="flex items-center gap-4">
+          {app && (
+            <Link href={`/apps/${app?.name}`}>
+              <Button variant="outline" size="sm">
+                Go to App
+              </Button>
+            </Link>
+          )}
+          {app && (
+            <AddAccountForm
+              appInfos={[
+                {
+                  name: app.name,
+                  logo: app.logo,
+                  securitySchemes: app.security_schemes,
+                },
+              ]}
+              updateLinkedAccounts={refreshLinkedAccounts}
+            />
+          )}
+        </div>
       </div>
 
       <Tabs defaultValue={"linked"} className="w-full">


### PR DESCRIPTION
🏷️ Ticket
Fixes #308 

📝 Description
This PR addresses the issue where the app title on the app configuration page is a clickable link, while app titles on other pages are not links, causing inconsistent UX.
Changes made:
Removed the link from the app title in the app configuration page
Added a dedicated "Go to App" button next to the add account form
Improved UI consistency to match how app titles are displayed on other pages


### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Go to App" button with an outline style and small size, placed next to the Add Account form for easier navigation.

- **Style**
	- Updated layout to display the "Go to App" button and Add Account form side by side with improved spacing.
	- The app name heading is no longer a clickable link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->