### PR TITLE
devx: update seed db script to only seed 3 apps with dummy oauth credentials

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -116,8 +116,49 @@ For VS Code users, configure Ruff formatter:
    docker compose exec runner ./scripts/seed_db.sh
    ```
 
-   The script will output an API key that you can use on the swagger UI or sending HTTP
-   requests to the local backend server directly.
+   The script will seed the database with below dummy data for local end-to-end development.
+   - A default project and agent (with an API key)
+   - Sample Apps and their functions
+     - `Brave Search`
+     - `Hacker News`
+     - `Gmail` (with dummy OAuth2 credentials)
+
+   The script will output an API key like below that you can use on the swagger UI, SDK, or
+   sending HTTP requests to the local backend server directly.
+
+   ```
+   {
+      'Project Id': '65cf26b9-a919-4008-85de-ecb850c3fc36',
+      'Agent Id': '74273ac1-f68e-4314-b8be-fee4a5855d8a',
+      'API Key': '88c55e31e817bd2d48aa455e94b61e766fb6e6610c97abe6f724733bf222e3e0'
+   }
+   ```
+
+   > [!NOTE]
+   > If you want to seed the database with all available apps, run the script with the `--all` flag.
+   > But you'll have to manually create a secrets file `.app.secrets.json`
+   > for each app that has OAuth2 scheme and put the OAuth2 credentials in that file, and the
+   > insertion process might take a while.
+   > See the example secrets file below for the `GMAIL` app.
+
+   ```bash
+   # put this in a file called .app.secrets.json under ./apps/gmail/
+   {
+      "AIPOLABS_GOOGLE_APP_CLIENT_ID": "<your_google_oauth2_client_id>",
+      "AIPOLABS_GOOGLE_APP_CLIENT_SECRET": "<your_google_oauth2_client_secret>"
+   }
+   ```
+
+1. (Optional) If you want to seed the database with specific `Apps` and `Functions`, use the cli command directly.
+   > [!NOTE]
+   > Add the `--skip-dry-run` flag to the commands below to actually insert the data into the database.
+
+   ```bash
+   # create app (--secrets-file is only needed for apps that have OAuth2 scheme)
+   docker compose exec runner python -m aci.cli upsert-app --app-file ./apps/gmail/app.json --secrets-file ./apps/gmail/.app.secrets.json
+   # create functions
+   docker compose exec runner python -m aci.cli upsert-functions --functions-file ./apps/gmail/functions.json
+   ```
 
 1. (Optional) Connect to the database using a GUI client (e.g., `DBeaver`)
 
@@ -139,9 +180,10 @@ For VS Code users, configure Ruff formatter:
 Ensure the `db` service is running and the database is empty (in case you have seeded
 the db in `step 6`) before running tests.
 
-More specifically, if you have run the `seed_db.sh` script already, you need to bring
-down docker compose and bring it up again without running the `seed_db.sh` script this
-time.
+> [!NOTE]
+> More specifically, if you have run the `seed_db.sh` script already, you need to bring
+> down docker compose and bring it up again without running the `seed_db.sh` script this
+> time.
 
 Then you can run the test in the `runner` container:
 

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -70,33 +70,29 @@ EOF
 
 seed_all_apps() {
   # Seed the database with Apps
-  if [ "$SEED_ALL" = true ]; then
-    for app_dir in ./apps/*/; do
-      app_file="${app_dir}app.json"
-      secrets_file="${app_dir}.app.secrets.json"
+  for app_dir in ./apps/*/; do
+    app_file="${app_dir}app.json"
+    secrets_file="${app_dir}.app.secrets.json"
 
-      # Check if secrets file exists and construct command accordingly
-      if [ -f "$secrets_file" ]; then
-        python -m aci.cli upsert-app \
-          --app-file "$app_file" \
-          --secrets-file "$secrets_file" \
-          --skip-dry-run
-      else
-        python -m aci.cli upsert-app \
-          --app-file "$app_file" \
-          --skip-dry-run
-      fi
-    done
-  fi
+    # Check if secrets file exists and construct command accordingly
+    if [ -f "$secrets_file" ]; then
+      python -m aci.cli upsert-app \
+        --app-file "$app_file" \
+        --secrets-file "$secrets_file" \
+        --skip-dry-run
+    else
+      python -m aci.cli upsert-app \
+        --app-file "$app_file" \
+        --skip-dry-run
+    fi
+  done
 
   # Seed the database with Functions
-  if [ "$SEED_FUNCTIONS" = true ]; then
-    for functions_file in ./apps/*/functions.json; do
-      python -m aci.cli upsert-functions \
-        --functions-file "$functions_file" \
-        --skip-dry-run
-    done
-  fi
+  for functions_file in ./apps/*/functions.json; do
+    python -m aci.cli upsert-functions \
+      --functions-file "$functions_file" \
+      --skip-dry-run
+  done
 }
 
 seed_required_data() {

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -99,7 +99,7 @@ seed_required_data() {
 
   # Seed the database with a default project and a default agent. The command will
   # output the API key of that agent that can be used in the swagger UI.
-  python -m aci.cli.aci create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
+  python -m aci.cli create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
 }
 
 # Execute the script functions

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -10,8 +10,6 @@ Options:
   -h, --help   Display this help message
   -a, --all    Seed all available Apps and Functions (without this flag, it will seed only a selected set of Apps and their Functions (with dummy OAuth2 client id & secret if it's OAuth2 app))
 
-
-If no arguments are provided, the script will seed everything.
 EOF
 }
 

--- a/backend/scripts/seed_db.sh
+++ b/backend/scripts/seed_db.sh
@@ -8,44 +8,26 @@ Usage: $0 [options]
 
 Options:
   -h, --help   Display this help message
-  plans        Seed only the subscription plans
-  apps         Seed only the apps
-  functions    Seed only the functions
-  user         Seed only the user resource
+  -a, --all    Seed all available Apps and Functions (without this flag, it will seed only a selected set of Apps and their Functions (with dummy OAuth2 client id & secret if it's OAuth2 app))
+
 
 If no arguments are provided, the script will seed everything.
 EOF
 }
 
-# Declare flags for seeding various resources
-SEED_PLANS=false
-SEED_APPS=false
-SEED_FUNCTIONS=false
-SEED_USER=false
+SEED_ALL=false
 
 parse_arguments() {
 
   if [ $# -eq 0 ]; then
-    # No arguments: default to seed everything
-    SEED_PLANS=true
-    SEED_APPS=true
-    SEED_FUNCTIONS=true
-    SEED_USER=true
+    # No arguments: default to seed selected test data
+    SEED_ALL=false
   else
     # Parse arguments
     for arg in "$@"; do
       case $arg in
-        plans)
-          SEED_PLANS=true
-          ;;
-        apps)
-          SEED_APPS=true
-          ;;
-        functions)
-          SEED_FUNCTIONS=true
-          ;;
-        user)
-          SEED_USER=true
+        -a|--all)
+          SEED_ALL=true
           ;;
         -h|--help)
           usage
@@ -61,45 +43,76 @@ parse_arguments() {
   fi
 }
 
-# Call our argument parser
-parse_arguments "$@"
 
-# Seed the database with a default project and a default agent. The command will
-# output the API key of that agent that can be used in the swagger UI.
-if [ "$SEED_USER" = true ]; then
-  python -m aci.cli.aci create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
-fi
+seed_test_apps() {
+  # Create a temporary file
+  temp_oauth2_secrets_file=$(mktemp)
 
-# Seed the database with Plans
-if [ "$SEED_PLANS" = true ]; then
+  # Make sure it gets deleted when the script exits
+  trap "rm -f $temp_oauth2_secrets_file" EXIT
+
+  # Add content to the temporary file
+  cat > "$temp_oauth2_secrets_file" <<EOF
+    {
+      "AIPOLABS_GOOGLE_APP_CLIENT_ID": "dummy_client_id",
+      "AIPOLABS_GOOGLE_APP_CLIENT_SECRET": "dummy_client_secret"
+    }
+EOF
+
+  python -m aci.cli upsert-app --app-file "./apps/brave_search/app.json" --skip-dry-run
+  python -m aci.cli upsert-app --app-file "./apps/hackernews/app.json" --skip-dry-run
+  python -m aci.cli upsert-app --app-file "./apps/gmail/app.json" --secrets-file "$temp_oauth2_secrets_file" --skip-dry-run
+
+  python -m aci.cli upsert-functions --functions-file "./apps/brave_search/functions.json" --skip-dry-run
+  python -m aci.cli upsert-functions --functions-file "./apps/hackernews/functions.json" --skip-dry-run
+  python -m aci.cli upsert-functions --functions-file "./apps/gmail/functions.json" --skip-dry-run
+}
+
+seed_all_apps() {
+  # Seed the database with Apps
+  if [ "$SEED_ALL" = true ]; then
+    for app_dir in ./apps/*/; do
+      app_file="${app_dir}app.json"
+      secrets_file="${app_dir}.app.secrets.json"
+
+      # Check if secrets file exists and construct command accordingly
+      if [ -f "$secrets_file" ]; then
+        python -m aci.cli upsert-app \
+          --app-file "$app_file" \
+          --secrets-file "$secrets_file" \
+          --skip-dry-run
+      else
+        python -m aci.cli upsert-app \
+          --app-file "$app_file" \
+          --skip-dry-run
+      fi
+    done
+  fi
+
+  # Seed the database with Functions
+  if [ "$SEED_FUNCTIONS" = true ]; then
+    for functions_file in ./apps/*/functions.json; do
+      python -m aci.cli upsert-functions \
+        --functions-file "$functions_file" \
+        --skip-dry-run
+    done
+  fi
+}
+
+seed_required_data() {
+  # Seed the database with Plans
   python -m aci.cli populate-subscription-plans --skip-dry-run
-fi
 
-# Seed the database with Apps
-if [ "$SEED_APPS" = true ]; then
-  for app_dir in ./apps/*/; do
-    app_file="${app_dir}app.json"
-    secrets_file="${app_dir}.app.secrets.json"
+  # Seed the database with a default project and a default agent. The command will
+  # output the API key of that agent that can be used in the swagger UI.
+  python -m aci.cli.aci create-random-api-key --visibility-access public --org-id 107e06da-e857-4864-bc1d-4adcba02ab76
+}
 
-    # Check if secrets file exists and construct command accordingly
-    if [ -f "$secrets_file" ]; then
-      python -m aci.cli upsert-app \
-        --app-file "$app_file" \
-        --secrets-file "$secrets_file" \
-        --skip-dry-run
-    else
-      python -m aci.cli upsert-app \
-        --app-file "$app_file" \
-        --skip-dry-run
-    fi
-  done
+# Execute the script functions
+parse_arguments "$@"
+if [ "$SEED_ALL" = true ]; then
+  seed_all_apps
+else
+  seed_test_apps
 fi
-
-# Seed the database with Functions
-if [ "$SEED_FUNCTIONS" = true ]; then
-  for functions_file in ./apps/*/functions.json; do
-    python -m aci.cli upsert-functions \
-      --functions-file "$functions_file" \
-      --skip-dry-run
-  done
-fi
+seed_required_data


### PR DESCRIPTION
### 📝 Description

- make the seed_db.sh script by default only seed essential data and 3 selected apps.
- update the readme to make it clear how dev can seed all or specific apps



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified instructions for database seeding, detailing seeded data, usage examples, and guidance for seeding all or specific apps.
  - Added examples for API key output and OAuth2 secrets file setup.

- **Chores**
  - Simplified the database seeding process with a single flag to seed all apps and functions or a default subset, streamlining the command-line interface for setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->