### PR TITLE
feat: add dismissible beta banner to Agent Playground page

### DIFF
--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -8,7 +8,7 @@ import { SettingsSidebar } from "./playground-settings";
 import { ChatInput } from "./chat-input";
 import { Messages } from "./messages";
 import { useShallow } from "zustand/react/shallow";
-
+import { BetaAlert } from "@/components/playground/beta-alert";
 const Page = () => {
   const { activeProject } = useMetaInfo();
 
@@ -108,6 +108,7 @@ const Page = () => {
     <div className="flex flex-grow h-[calc(100vh-6rem)]">
       {/* Left part - Chat area */}
       <div className="flex-1 flex flex-col overflow-hidden">
+        <BetaAlert />
         <Messages messages={messages} status={status} />
         <ChatInput
           input={input}

--- a/frontend/src/components/playground/beta-alert.tsx
+++ b/frontend/src/components/playground/beta-alert.tsx
@@ -1,0 +1,32 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { X } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export const BetaAlert = () => {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+
+  return (
+    <Alert
+      variant="default"
+      className={cn(
+        "relative m-1 w-[calc(100%-0.5rem)] pr-10",
+        "bg-blue-100 text-blue-800 border border-blue-200",
+      )}
+    >
+      <AlertDescription>
+        Agent Playground is a beta feature and not recommended for production
+        use. Expect limited stability and possible changes.
+      </AlertDescription>
+
+      <button
+        className="absolute top-2 right-2 text-blue-800 hover:text-blue-600"
+        onClick={() => setVisible(false)}
+        aria-label="Close beta alert"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </Alert>
+  );
+};

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
### 🏷️ Ticket


### 📝 Description
This PR adds a dismissible BetaAlert component to the Agent Playground page. The alert informs users that the feature is in beta and may not be stable for production use. It follows Shadcn UI structure with Tailwind styling and is dismissible via a close icon. The banner is locally scoped and not abstracted into a shared component yet.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/42df6a8f-4bb7-4b10-a8ff-8aa6d54fd2ef)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dismissible alert to the Agent Playground, notifying users that the feature is in beta and may not be stable for production use.
  - Introduced new UI components for displaying customizable alert messages throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->