### PR TITLE
Refactor: remove server metadata url

### DIFF
--- a/backend/aci/cli/tests/conftest.py
+++ b/backend/aci/cli/tests/conftest.py
@@ -75,7 +75,9 @@ def dummy_app_data() -> dict:
                 "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
                 "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
                 "scope": "openid email profile https://www.googleapis.com/auth/calendar",
-                "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration",
+                "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                "access_token_url": "https://oauth2.googleapis.com/token",
+                "refresh_token_url": "https://oauth2.googleapis.com/token",
             }
         },
         "default_security_credentials_by_scheme": {},

--- a/backend/aci/common/schemas/security_scheme.py
+++ b/backend/aci/common/schemas/security_scheme.py
@@ -1,6 +1,6 @@
 from typing import TypeVar
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from aci.common.enums import HttpLocation
 
@@ -47,42 +47,23 @@ class OAuth2Scheme(BaseModel):
         description="Space separated scopes of the OAuth2 client (provided by ACI) used for the app, "
         "e.g., 'openid email profile https://www.googleapis.com/auth/calendar'",
     )
+    authorize_url: str = Field(
+        ...,
+        description="The URL of the OAuth2 authorization server, e.g., 'https://accounts.google.com/o/oauth2/v2/auth'",
+    )
+    access_token_url: str = Field(
+        ...,
+        description="The URL of the OAuth2 access token server, e.g., 'https://oauth2.googleapis.com/token'",
+    )
+    refresh_token_url: str = Field(
+        ...,
+        description="The URL of the OAuth2 refresh token server, e.g., 'https://oauth2.googleapis.com/token'",
+    )
     token_endpoint_auth_method: str | None = Field(
         default=None,
         description="The authentication method for the OAuth2 token endpoint, e.g., 'client_secret_post' "
         "for some providers that require client_id/client_secret to be sent in the body of the token request, like Hubspot",
     )
-    # making below fields optional because if server_metadata_url is provided, the other endpoints are usually not needed
-    authorize_url: str | None = Field(
-        default=None,
-        description="The URL of the OAuth2 authorization server, e.g., 'https://accounts.google.com/o/oauth2/auth'",
-    )
-    access_token_url: str | None = Field(
-        default=None,
-        description="The URL of the OAuth2 access token server, e.g., 'https://oauth2.googleapis.com/token'",
-    )
-    refresh_token_url: str | None = Field(
-        default=None,
-        description="The URL of the OAuth2 refresh token server, e.g., 'https://oauth2.googleapis.com/token'",
-    )
-    server_metadata_url: str | None = Field(
-        default=None,
-        description="The URL of the OAuth2 server metadata/discovery doc, e.g., 'https://accounts.google.com/.well-known/openid-configuration'",
-    )
-
-    # validation: if server_metadata_url is None, the other urls must NOT be None
-    @model_validator(mode="after")
-    def validate_urls(self) -> "OAuth2Scheme":
-        if self.server_metadata_url is None:
-            if (
-                self.authorize_url is None
-                or self.access_token_url is None
-                or self.refresh_token_url is None
-            ):
-                raise ValueError(
-                    "If server_metadata_url is not provided, the other endpoints must be provided"
-                )
-        return self
 
 
 class NoAuthScheme(BaseModel, extra="forbid"):

--- a/backend/aci/server/oauth2.py
+++ b/backend/aci/server/oauth2.py
@@ -26,14 +26,13 @@ def create_oauth2_client(
     client_id: str,
     client_secret: str,
     scope: str,
+    authorize_url: str,
+    access_token_url: str,
+    refresh_token_url: str,
     prompt: str = "consent",
     code_challenge_method: str = "S256",
     access_type: str = "offline",
     token_endpoint_auth_method: str | None = None,
-    authorize_url: str | None = None,
-    access_token_url: str | None = None,
-    refresh_token_url: str | None = None,
-    server_metadata_url: str | None = None,
 ) -> StarletteOAuth2App:
     """
     Create an OAuth2 client for the given app.
@@ -48,13 +47,10 @@ def create_oauth2_client(
             "code_challenge_method": code_challenge_method,
             "token_endpoint_auth_method": token_endpoint_auth_method,
         },
-        # Note: usually if server_metadata_url (e.g., google's discovery doc https://accounts.google.com/.well-known/openid-configuration)
-        # is provided, the other endpoints are not needed.
         authorize_url=authorize_url,
         authorize_params={"access_type": access_type},
         access_token_url=access_token_url,
         refresh_token_url=refresh_token_url,
-        server_metadata_url=server_metadata_url,
     )
     return cast(StarletteOAuth2App, oauth_client)
 

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -366,8 +366,6 @@ async def link_oauth2_account(
             f"{app_configuration.security_scheme}, not OAuth2"
         )
 
-    # TODO: add correspinding validation of the oauth2 fields (e.g., client_id, client_secret, scope, etc.)
-    # when indexing an App. For example, if server_metadata_url is None, other url must be provided
     # TODO: load client's overrides if they specify any, for example, client_id, client_secret, scope, etc.
     # security_scheme of the app configuration must be one of the App's security_schemes, so we can safely validate it
     app_default_oauth2_config = OAuth2Scheme.model_validate(
@@ -378,11 +376,10 @@ async def link_oauth2_account(
         client_id=app_default_oauth2_config.client_id,
         client_secret=app_default_oauth2_config.client_secret,
         scope=app_default_oauth2_config.scope,
-        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
         authorize_url=app_default_oauth2_config.authorize_url,
         access_token_url=app_default_oauth2_config.access_token_url,
         refresh_token_url=app_default_oauth2_config.refresh_token_url,
-        server_metadata_url=app_default_oauth2_config.server_metadata_url,
+        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
     )
     path = request.url_for(LINKED_ACCOUNTS_OAUTH2_CALLBACK_ROUTE_NAME).path
     redirect_uri = f"{config.REDIRECT_URI_BASE}{path}"
@@ -399,7 +396,7 @@ async def link_oauth2_account(
     # {
     #     "code_verifier": "...",
     #     "state": "...",
-    #     "url": "https://accounts.google.com/o/oauth2/auth?client_id=...&redirect_uri=...&scope=...&response_type=code&access_type=offline&state=...&code_verifier=...&nonce=...",
+    #     "url": "https://accounts.google.com/o/oauth2/v2/auth?client_id=...&redirect_uri=...&scope=...&response_type=code&access_type=offline&state=...&code_verifier=...&nonce=...",
     #     "nonce": "..."
     # }
 
@@ -529,11 +526,10 @@ async def linked_accounts_oauth2_callback(
         client_id=app_default_oauth2_config.client_id,
         client_secret=app_default_oauth2_config.client_secret,
         scope=app_default_oauth2_config.scope,
-        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
         authorize_url=app_default_oauth2_config.authorize_url,
         access_token_url=app_default_oauth2_config.access_token_url,
         refresh_token_url=app_default_oauth2_config.refresh_token_url,
-        server_metadata_url=app_default_oauth2_config.server_metadata_url,
+        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
     )
 
     # get oauth2 account credentials

--- a/backend/aci/server/security_credentials_manager.py
+++ b/backend/aci/server/security_credentials_manager.py
@@ -151,11 +151,10 @@ async def _refresh_oauth2_access_token(app: App, refresh_token: str) -> dict:
         client_id=app_default_oauth2_config.client_id,
         client_secret=app_default_oauth2_config.client_secret,
         scope=app_default_oauth2_config.scope,
-        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
         authorize_url=app_default_oauth2_config.authorize_url,
         access_token_url=app_default_oauth2_config.access_token_url,
         refresh_token_url=app_default_oauth2_config.refresh_token_url,
-        server_metadata_url=app_default_oauth2_config.server_metadata_url,
+        token_endpoint_auth_method=app_default_oauth2_config.token_endpoint_auth_method,
     )
     # TODO: error handling for oauth2 methods
     token_response = await oauth2.refresh_access_token(oauth2_client, refresh_token)

--- a/backend/aci/server/tests/crud/custom_sql_types/test_encrypted_security_schemes.py
+++ b/backend/aci/server/tests/crud/custom_sql_types/test_encrypted_security_schemes.py
@@ -21,7 +21,9 @@ def test_app_table_security_schemes_column_encryption(db_session: Session) -> No
             client_id="test_client_id",
             client_secret=expected_client_secret,
             scope="openid email profile",
-            server_metadata_url="https://example.com/metadata",
+            authorize_url="https://example.com/auth",
+            access_token_url="https://example.com/access_token",
+            refresh_token_url="https://example.com/refresh_token",
         ).model_dump()
     }
 
@@ -89,7 +91,9 @@ def test_app_configuration_table_security_scheme_overrides_column_encryption(
             client_id="test_client_id",
             client_secret=expected_client_secret,
             scope="openid email profile",
-            server_metadata_url="https://example.com/metadata",
+            authorize_url="https://example.com/auth",
+            access_token_url="https://example.com/access_token",
+            refresh_token_url="https://example.com/refresh_token",
         ).model_dump()
     }
 
@@ -143,7 +147,7 @@ def test_app_table_security_schemes_column_mutable_dict_detection(db_session: Se
     and save it to the database.
     """
     # Given - Create test data
-    initial_metadata_url = "https://example.com/metadata"
+    initial_authorize_url = "https://example.com/auth"
     security_schemes = {
         SecurityScheme.OAUTH2: OAuth2Scheme(
             location=HttpLocation.HEADER,
@@ -152,7 +156,9 @@ def test_app_table_security_schemes_column_mutable_dict_detection(db_session: Se
             client_id="test_client_id",
             client_secret="very_secret_value",
             scope="openid email profile",
-            server_metadata_url=initial_metadata_url,
+            authorize_url=initial_authorize_url,
+            access_token_url="https://example.com/access_token",
+            refresh_token_url="https://example.com/refresh_token",
         ).model_dump()
     }
 
@@ -175,9 +181,9 @@ def test_app_table_security_schemes_column_mutable_dict_detection(db_session: Se
     db_session.commit()
 
     # When - Update the security_schemes
-    new_metadata_url = "https://example.com/new_metadata"
+    new_authorize_url = "https://example.com/new_auth"
     new_security_schemes = app.security_schemes[SecurityScheme.OAUTH2].copy()
-    new_security_schemes["server_metadata_url"] = new_metadata_url
+    new_security_schemes["authorize_url"] = new_authorize_url
 
     app.security_schemes[SecurityScheme.OAUTH2] = new_security_schemes
     db_session.commit()
@@ -187,8 +193,7 @@ def test_app_table_security_schemes_column_mutable_dict_detection(db_session: Se
     retrieved_app = db_session.query(App).filter_by(name="test_app").first()
     assert retrieved_app is not None
     assert (
-        retrieved_app.security_schemes[SecurityScheme.OAUTH2]["server_metadata_url"]
-        == new_metadata_url
+        retrieved_app.security_schemes[SecurityScheme.OAUTH2]["authorize_url"] == new_authorize_url
     )
 
 
@@ -202,7 +207,7 @@ def test_app_configuration_table_security_scheme_overrides_column_mutable_dict_d
     and save it to the database.
     """
     # Given - Create and save AppConfiguration with security_scheme_overrides
-    initial_metadata_url = "https://example.com/metadata"
+    initial_authorize_url = "https://example.com/auth"
     security_scheme_overrides = {
         SecurityScheme.OAUTH2: OAuth2Scheme(
             location=HttpLocation.HEADER,
@@ -211,7 +216,9 @@ def test_app_configuration_table_security_scheme_overrides_column_mutable_dict_d
             client_id="test_client_id",
             client_secret="very_secret_value",
             scope="openid email profile",
-            server_metadata_url=initial_metadata_url,
+            authorize_url=initial_authorize_url,
+            access_token_url="https://example.com/access_token",
+            refresh_token_url="https://example.com/refresh_token",
         ).model_dump()
     }
     app_config = AppConfiguration(
@@ -227,11 +234,11 @@ def test_app_configuration_table_security_scheme_overrides_column_mutable_dict_d
     db_session.commit()
 
     # When - Update the security_scheme_overrides
-    new_metadata_url = "https://example.com/new_metadata"
+    new_authorize_url = "https://example.com/new_auth"
     new_security_scheme_overrides = app_config.security_scheme_overrides[
         SecurityScheme.OAUTH2
     ].copy()
-    new_security_scheme_overrides["server_metadata_url"] = new_metadata_url
+    new_security_scheme_overrides["authorize_url"] = new_authorize_url
 
     app_config.security_scheme_overrides[SecurityScheme.OAUTH2] = new_security_scheme_overrides
     db_session.commit()
@@ -242,6 +249,6 @@ def test_app_configuration_table_security_scheme_overrides_column_mutable_dict_d
     retrieved_app_config = db_session.query(AppConfiguration).filter_by(id=app_config_id).first()
     assert retrieved_app_config is not None
     assert (
-        retrieved_app_config.security_scheme_overrides[SecurityScheme.OAUTH2]["server_metadata_url"]
-        == new_metadata_url
+        retrieved_app_config.security_scheme_overrides[SecurityScheme.OAUTH2]["authorize_url"]
+        == new_authorize_url
     )

--- a/backend/aci/server/tests/dummy_apps/google/app.json
+++ b/backend/aci/server/tests/dummy_apps/google/app.json
@@ -17,7 +17,9 @@
             "client_id": "mock_client_id",
             "client_secret": "mock_client_secret",
             "scope": "openid email profile https://www.googleapis.com/auth/calendar",
-            "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+            "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+            "access_token_url": "https://oauth2.googleapis.com/token",
+            "refresh_token_url": "https://oauth2.googleapis.com/token"
         }
     },
     "default_security_credentials_by_scheme": {},

--- a/backend/aci/server/tests/dummy_apps/mock_app_connector/app.json
+++ b/backend/aci/server/tests/dummy_apps/mock_app_connector/app.json
@@ -13,7 +13,9 @@
             "client_id": "mock_client_id",
             "client_secret": "mock_client_secret",
             "scope": "openid email profile https://www.googleapis.com/auth/calendar",
-            "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+            "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+            "access_token_url": "https://oauth2.googleapis.com/token",
+            "refresh_token_url": "https://oauth2.googleapis.com/token"
         },
         "no_auth": {}
     },

--- a/backend/apps/discord/app.json
+++ b/backend/apps/discord/app.json
@@ -13,7 +13,6 @@
       "client_id": "{{ AIPOLABS_DISCORD_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_DISCORD_APP_CLIENT_SECRET }}",
       "scope": "identify email openid connections guilds guilds.join guilds.members.read applications.commands messages.read",
-      "server_metadata_url": "https://discord.com/.well-known/openid-configuration",
       "token_endpoint_auth_method": "client_secret_post",
       "authorize_url": "https://discord.com/api/oauth2/authorize",
       "access_token_url": "https://discord.com/api/oauth2/token",

--- a/backend/apps/github/app.json
+++ b/backend/apps/github/app.json
@@ -15,7 +15,7 @@
       "scope": "public_repo gist user workflow",
       "authorize_url": "https://github.com/login/oauth/authorize",
       "access_token_url": "https://github.com/login/oauth/access_token",
-      "refresh_token_url": ""
+      "refresh_token_url": "https://github.com/login/oauth/access_token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/gmail/app.json
+++ b/backend/apps/gmail/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/gmail.labels https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.insert https://www.googleapis.com/auth/gmail.modify https://mail.google.com/",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_analytics/app.json
+++ b/backend/apps/google_analytics/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/analytics.readonly https://www.googleapis.com/auth/analytics.edit",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_calendar/app.json
+++ b/backend/apps/google_calendar/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "openid email profile https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_docs/app.json
+++ b/backend/apps/google_docs/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/documents",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_sheets/app.json
+++ b/backend/apps/google_sheets/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/spreadsheets",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_tasks/app.json
+++ b/backend/apps/google_tasks/app.json
@@ -13,7 +13,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/tasks",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/slack/app.json
+++ b/backend/apps/slack/app.json
@@ -13,7 +13,6 @@
       "client_id": "{{ AIPOLABS_SLACK_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_SLACK_APP_CLIENT_SECRET }}",
       "scope": "users:read users:write channels:read groups:read groups:write im:read im:write mpim:read chat:write channels:history groups:history mpim:history im:history bookmarks:write bookmarks:read pins:write pins:read reactions:read reactions:write reminders:write reminders:read emoji:read search:read team:read",
-      "server_metadata_url": "https://slack.com/.well-known/openid-configuration",
       "token_endpoint_auth_method": "client_secret_post",
       "authorize_url": "https://slack.com/oauth/v2/authorize",
       "access_token_url": "https://slack.com/api/oauth.v2.access",

--- a/backend/apps/youtube/app.json
+++ b/backend/apps/youtube/app.json
@@ -15,7 +15,9 @@
       "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
       "scope": "https://www.googleapis.com/auth/youtube https://www.googleapis.com/auth/youtube.channel-memberships.creator https://www.googleapis.com/auth/youtube.force-ssl https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtube.upload https://www.googleapis.com/auth/youtubepartner https://www.googleapis.com/auth/youtubepartner-channel-audit",
-      "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration"
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},


### PR DESCRIPTION
### 📝 Description

Remove server_metadata_url for consistency and clarity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OAuth2 configurations now require explicit specification of authorization, access token, and refresh token URLs, replacing the previous use of a metadata discovery URL.

- **Bug Fixes**
  - Improved consistency and clarity in OAuth2 configuration across all app integrations.

- **Chores**
  - Updated test data and documentation to align with the new OAuth2 configuration requirements.
  - Removed deprecated metadata URL fields from all relevant app configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->