### PR TITLE
No need to seed again after server restart

### DIFF
--- a/backend/scripts/create-kms-encryption-key.sh
+++ b/backend/scripts/create-kms-encryption-key.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-
 # This script is mounted into the localstack container to run during its container
 # startup.
-
 # This command creates a KMS key in the aws localstack container with an id of
 # 00000000-0000-0000-0000-000000000001. This key is used as the key encryption
 # key in local docker compose environment for the common/encryption.py module.
-awslocal kms create-key --region us-east-2 --tags '[{"TagKey":"_custom_id_","TagValue":"00000000-0000-0000-0000-000000000001"}]'
+# Using fixed custom key material ensures the same key is generated each time
+
+FIXED_KEY_MATERIAL="U2FsdGVkX1+K8yfnrMn+QRyh2nWPfI9wXA84BGm6YAA="
+awslocal kms create-key --region us-east-2 --tags '[{"TagKey":"_custom_id_","TagValue":"00000000-0000-0000-0000-000000000001"},{"TagKey":"_custom_key_material_","TagValue":"'"$FIXED_KEY_MATERIAL"'"}]'


### PR DESCRIPTION
### 🏷️ Ticket

 #341 

### 📝 Description

Included `_custom_key_material_` for the `TagKey` so that kms generates the same key each time

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the KMS key creation process to use fixed key material, ensuring consistent key generation across script runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->