### PR TITLE
fix: Update sentry project name from "javascript-nextjs" to "aci-dev-portal"

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -37,7 +37,7 @@ export default withSentryConfig(nextConfig, {
   // https://github.com/getsentry/sentry-webpack-plugin#options
 
   org: "aipotheosis-labs",
-  project: "javascript-nextjs",
+  project: "aci-dev-portal",
 
   // Only print logs for uploading source maps in CI
   // CI=true is automatically set by GitHub Actions and other CI tools


### PR DESCRIPTION
### 🏷️ Ticket

No ticket.

### 📝 Description

Update sentry project name from "javascript-nextjs" to "aci-dev-portal" to solve the `Sentry Project Not Found` error in Vercel build stage.

Here's the Vercel build log for this PR: https://vercel.com/obnoxiousproxys-projects/aci-dev-portal/DiUcc6atP6ZkcPpXxpmwKRiBzCnT
You can see that the source map is successfully uploaded to Sentry.


### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated error tracking configuration to use a new Sentry project for improved monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->