### PR TITLE
persistence playground

### DIFF
--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -35,8 +35,13 @@ const Page = () => {
   const getMessagesFromLocalStorage = () => {
     const storedMessages = localStorage.getItem(chatHistoryLocalStorageKey);
     if (storedMessages) {
-      const messages = JSON.parse(storedMessages) as Message[];
-      return messages;
+      try {
+        const messages = JSON.parse(storedMessages) as Message[];
+        return messages;
+      } catch (error) {
+        console.error("Failed to parse stored messages:", error);
+        return [];
+      }
     }
     return [];
   };

--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useMetaInfo } from "@/components/context/metainfo";
-import { useChat } from "@ai-sdk/react";
+import { Message, useChat } from "@ai-sdk/react";
 import { useAgentStore } from "@/lib/store/agent";
 import { SettingsSidebar } from "./playground-settings";
 import { ChatInput } from "./chat-input";
 import { Messages } from "./messages";
 import { useShallow } from "zustand/react/shallow";
 import { BetaAlert } from "@/components/playground/beta-alert";
+import { useEffect } from "react";
+
+const chatHistoryLocalStorageKey = `playground-chat-history`;
 const Page = () => {
   const { activeProject } = useMetaInfo();
 
@@ -29,6 +32,14 @@ const Page = () => {
   // Only compute this when activeProject changes
   const apiKey = activeProject ? getApiKey(activeProject) : "";
 
+  const getMessagesFromLocalStorage = () => {
+    const storedMessages = localStorage.getItem(chatHistoryLocalStorageKey);
+    if (storedMessages) {
+      const messages = JSON.parse(storedMessages) as Message[];
+      return messages;
+    }
+    return [];
+  };
   const {
     messages,
     input,
@@ -54,8 +65,12 @@ const Page = () => {
     onFinish: (message) => {
       console.log(message);
     },
+    initialMessages: getMessagesFromLocalStorage(),
   });
 
+  useEffect(() => {
+    localStorage.setItem(chatHistoryLocalStorageKey, JSON.stringify(messages));
+  }, [messages]);
   const handleAddToolResult = ({
     toolCallId,
     result,

--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -33,7 +33,7 @@ const Page = () => {
   const apiKey = activeProject ? getApiKey(activeProject) : "";
 
   const getMessagesFromLocalStorage = () => {
-    const storedMessages = localStorage.getItem(chatHistoryLocalStorageKey);
+    const storedMessages = sessionStorage.getItem(chatHistoryLocalStorageKey);
     if (storedMessages) {
       try {
         const messages = JSON.parse(storedMessages) as Message[];
@@ -74,7 +74,10 @@ const Page = () => {
   });
 
   useEffect(() => {
-    localStorage.setItem(chatHistoryLocalStorageKey, JSON.stringify(messages));
+    sessionStorage.setItem(
+      chatHistoryLocalStorageKey,
+      JSON.stringify(messages),
+    );
   }, [messages]);
   const handleAddToolResult = ({
     toolCallId,

--- a/frontend/src/lib/store/agent.ts
+++ b/frontend/src/lib/store/agent.ts
@@ -169,7 +169,7 @@ export const useAgentStore = create<AgentState>()(
     }),
     {
       name: "playground-config-history",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         selectedApps: state.selectedApps,
         selectedLinkedAccountOwnerId: state.selectedLinkedAccountOwnerId,

--- a/frontend/src/lib/store/agent.ts
+++ b/frontend/src/lib/store/agent.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import { getApiKey } from "../api/util";
 import { Project } from "../types/project";
 import { LinkedAccount } from "../types/linkedaccount";
@@ -36,131 +37,145 @@ interface AgentState {
   initializeFromProject: (project: Project) => void;
 }
 
-export const useAgentStore = create<AgentState>()((set, get) => ({
-  selectedApps: [],
-  selectedLinkedAccountOwnerId: "",
-  allowedApps: [],
-  selectedFunctions: [],
-  selectedAgent: "",
-  linkedAccounts: [],
-  agents: [],
-  apps: [],
-  appFunctions: [],
-  loadingFunctions: false,
-  setSelectedApps: (apps: string[]) =>
-    set((state) => ({ ...state, selectedApps: apps })),
-  setSelectedLinkedAccountOwnerId: (id: string) =>
-    set((state) => ({ ...state, selectedLinkedAccountOwnerId: id })),
-  setAllowedApps: (apps: string[]) =>
-    set((state) => ({ ...state, allowedApps: apps })),
-  setSelectedFunctions: (functions: string[]) =>
-    set((state) => ({ ...state, selectedFunctions: functions })),
-  setSelectedAgent: (id: string) =>
-    set((state) => ({ ...state, selectedAgent: id })),
-  setAgents: (agents: Agent[]) =>
-    set((state) => ({ ...state, agents: agents })),
-  getApiKey: (activeProject: Project) => {
-    const apiKey = getApiKey(activeProject, get().selectedAgent);
-    return apiKey;
-  },
-  fetchLinkedAccounts: async (apiKey: string) => {
-    try {
-      const accounts = await getAllLinkedAccounts(apiKey);
-      set((state) => ({ ...state, linkedAccounts: accounts }));
-      return accounts;
-    } catch (error) {
-      console.error("Failed to fetch linked accounts:", error);
-      throw error;
-    }
-  },
-  getUniqueLinkedAccounts: () => {
-    const linkedAccounts = get().linkedAccounts;
-    const uniqueLinkedAccounts = Array.from(
-      new Map(
-        linkedAccounts.map((account) => [
-          account.linked_account_owner_id,
-          account,
-        ]),
-      ).values(),
-    );
-    return uniqueLinkedAccounts;
-  },
+export const useAgentStore = create<AgentState>()(
+  persist(
+    (set, get) => ({
+      selectedApps: [],
+      selectedLinkedAccountOwnerId: "",
+      allowedApps: [],
+      selectedFunctions: [],
+      selectedAgent: "",
+      linkedAccounts: [],
+      agents: [],
+      apps: [],
+      appFunctions: [],
+      loadingFunctions: false,
+      setSelectedApps: (apps: string[]) =>
+        set((state) => ({ ...state, selectedApps: apps })),
+      setSelectedLinkedAccountOwnerId: (id: string) =>
+        set((state) => ({ ...state, selectedLinkedAccountOwnerId: id })),
+      setAllowedApps: (apps: string[]) =>
+        set((state) => ({ ...state, allowedApps: apps })),
+      setSelectedFunctions: (functions: string[]) =>
+        set((state) => ({ ...state, selectedFunctions: functions })),
+      setSelectedAgent: (id: string) =>
+        set((state) => ({ ...state, selectedAgent: id })),
+      setAgents: (agents: Agent[]) =>
+        set((state) => ({ ...state, agents: agents })),
+      getApiKey: (activeProject: Project) => {
+        const apiKey = getApiKey(activeProject, get().selectedAgent);
+        return apiKey;
+      },
+      fetchLinkedAccounts: async (apiKey: string) => {
+        try {
+          const accounts = await getAllLinkedAccounts(apiKey);
+          set((state) => ({ ...state, linkedAccounts: accounts }));
+          return accounts;
+        } catch (error) {
+          console.error("Failed to fetch linked accounts:", error);
+          throw error;
+        }
+      },
+      getUniqueLinkedAccounts: () => {
+        const linkedAccounts = get().linkedAccounts;
+        const uniqueLinkedAccounts = Array.from(
+          new Map(
+            linkedAccounts.map((account) => [
+              account.linked_account_owner_id,
+              account,
+            ]),
+          ).values(),
+        );
+        return uniqueLinkedAccounts;
+      },
 
-  fetchApps: async (apiKey: string) => {
-    try {
-      const apps = await getApps([], apiKey);
-      set((state) => ({ ...state, apps: apps }));
-      return apps;
-    } catch (error) {
-      console.error("Failed to fetch apps:", error);
-      throw error;
-    }
-  },
-  getAvailableApps: () => {
-    let filteredApps = get().apps.filter((app) =>
-      get().allowedApps.includes(app.name),
-    );
-    // filter from linked accounts
-    if (!get().selectedLinkedAccountOwnerId) {
-      filteredApps = filteredApps.filter((app) =>
-        get().linkedAccounts.some(
-          (linkedAccount) => linkedAccount.app_name === app.name,
-        ),
-      );
-    } else {
-      filteredApps = filteredApps.filter((app) =>
-        get().linkedAccounts.some(
-          (linkedAccount) =>
-            linkedAccount.app_name === app.name &&
-            linkedAccount.linked_account_owner_id ===
-              get().selectedLinkedAccountOwnerId,
-        ),
-      );
-    }
-    return filteredApps;
-  },
-  fetchAppFunctions: async (apiKey: string) => {
-    set((state) => ({ ...state, loadingFunctions: true }));
-    try {
-      let functionsData = await searchFunctions(
-        {
-          allowed_apps_only: true,
-        },
-        apiKey,
-      );
-      functionsData = functionsData.sort((a, b) =>
-        a.name.localeCompare(b.name),
-      );
+      fetchApps: async (apiKey: string) => {
+        try {
+          const apps = await getApps([], apiKey);
+          set((state) => ({ ...state, apps: apps }));
+          return apps;
+        } catch (error) {
+          console.error("Failed to fetch apps:", error);
+          throw error;
+        }
+      },
+      getAvailableApps: () => {
+        let filteredApps = get().apps.filter((app) =>
+          get().allowedApps.includes(app.name),
+        );
+        // filter from linked accounts
+        if (!get().selectedLinkedAccountOwnerId) {
+          filteredApps = filteredApps.filter((app) =>
+            get().linkedAccounts.some(
+              (linkedAccount) => linkedAccount.app_name === app.name,
+            ),
+          );
+        } else {
+          filteredApps = filteredApps.filter((app) =>
+            get().linkedAccounts.some(
+              (linkedAccount) =>
+                linkedAccount.app_name === app.name &&
+                linkedAccount.linked_account_owner_id ===
+                  get().selectedLinkedAccountOwnerId,
+            ),
+          );
+        }
+        return filteredApps;
+      },
+      fetchAppFunctions: async (apiKey: string) => {
+        set((state) => ({ ...state, loadingFunctions: true }));
+        try {
+          let functionsData = await searchFunctions(
+            {
+              allowed_apps_only: true,
+            },
+            apiKey,
+          );
+          functionsData = functionsData.sort((a, b) =>
+            a.name.localeCompare(b.name),
+          );
 
-      set((state) => ({ ...state, appFunctions: functionsData }));
-      return functionsData;
-    } catch (error) {
-      console.error("Failed to fetch functions:", error);
-      throw error;
-    } finally {
-      set((state) => ({ ...state, loadingFunctions: false }));
-    }
-  },
-  getAvailableAppFunctions: () => {
-    const { selectedApps } = get();
-    if (selectedApps.length === 0) {
-      return [];
-    }
-    return get().appFunctions.filter((func) =>
-      selectedApps.some((appName) =>
-        func.name.startsWith(`${appName.toUpperCase()}__`),
-      ),
-    );
-  },
-  initializeFromProject: (project: Project) => {
-    if (project?.agents && project.agents.length > 0) {
-      // set default agent
-      set((state) => ({
-        ...state,
-        agents: project.agents,
-        selectedAgent: project.agents[0].id,
-        allowedApps: project.agents[0].allowed_apps || [],
-      }));
-    }
-  },
-}));
+          set((state) => ({ ...state, appFunctions: functionsData }));
+          return functionsData;
+        } catch (error) {
+          console.error("Failed to fetch functions:", error);
+          throw error;
+        } finally {
+          set((state) => ({ ...state, loadingFunctions: false }));
+        }
+      },
+      getAvailableAppFunctions: () => {
+        const { selectedApps } = get();
+        if (selectedApps.length === 0) {
+          return [];
+        }
+        return get().appFunctions.filter((func) =>
+          selectedApps.some((appName) =>
+            func.name.startsWith(`${appName.toUpperCase()}__`),
+          ),
+        );
+      },
+      initializeFromProject: (project: Project) => {
+        if (project?.agents && project.agents.length > 0) {
+          // set default agent
+          set((state) => ({
+            ...state,
+            agents: project.agents,
+            selectedAgent: project.agents[0].id,
+            allowedApps: project.agents[0].allowed_apps || [],
+          }));
+        }
+      },
+    }),
+    {
+      name: "playground-config-history",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        selectedApps: state.selectedApps,
+        selectedLinkedAccountOwnerId: state.selectedLinkedAccountOwnerId,
+        selectedFunctions: state.selectedFunctions,
+        selectedAgent: state.selectedAgent,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
### 🏷️ Ticket
#302 

### 📝 Description
used zustand's persist function to persist the setting in local,
created a useeffect to track changes in messages state and when change store it in the local

### 🎥 Demo (if applicable)
[persistent playgroun.zip](https://github.com/user-attachments/files/20153033/persistent.playgroun.zip)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ x] I have linked this PR to an issue or a ticket (required)
- [ x] I have updated the documentation related to my change if needed
- [ x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat history is now automatically saved and restored within the session, enabling users to continue conversations after page reloads.
  - Playground configuration, including selected apps, linked account, functions, and agent, is persisted in session storage to retain user selections across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->