### PR TITLE
add GITHUB__CREATE_REPOSITORY

### DIFF
--- a/backend/apps/github/functions.json
+++ b/backend/apps/github/functions.json
@@ -3236,5 +3236,109 @@
             ],
             "additionalProperties": false
         }
+    },
+    {
+        "name": "GITHUB__CREATE_REPOSITORY",
+        "description": "Creates a new repository for the authenticated user",
+        "tags": [
+            "repository",
+            "create",
+            "authenticated-user",
+            "user-repo",
+            "git"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/user/repos",
+            "server_url": "https://api.github.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "type": "object",
+                    "description": "Headers for the http request",
+                    "properties": {
+                        "accept": {
+                            "type": "string",
+                            "description": "Accept header",
+                            "default": "application/vnd.github+json"
+                        },
+                        "user-agent": {
+                            "type": "string",
+                            "description": "User-Agent header",
+                            "default": "ACI::GITHUB"
+                        },
+                        "content-type": {
+                            "type": "string",
+                            "description": "Content-Type header",
+                            "default": "application/json"
+                        }
+                    },
+                    "required": [
+                        "accept",
+                        "user-agent",
+                        "content-type"
+                    ],
+                    "visible": [],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "The JSON payload containing repository details",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the repository"
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "A short description of the repository"
+                        },
+                        "private": {
+                            "type": "boolean",
+                            "description": "Whether the repository is private",
+                            "default": false
+                        },
+                        "auto_init": {
+                            "type": "boolean",
+                            "description": "Whether to create an initial commit with README",
+                            "default": false
+                        },
+                        "gitignore_template": {
+                            "type": "string",
+                            "description": "The gitignore template to use"
+                        },
+                        "license_template": {
+                            "type": "string",
+                            "description": "The license template to use"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "visible": [
+                        "name",
+                        "description",
+                        "private",
+                        "auto_init",
+                        "gitignore_template",
+                        "license_template"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "header",
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
     }
 ]

--- a/backend/apps/github/functions.json
+++ b/backend/apps/github/functions.json
@@ -3243,9 +3243,7 @@
         "tags": [
             "repository",
             "create",
-            "authenticated-user",
-            "user-repo",
-            "git"
+            "authenticated-user"
         ],
         "visibility": "public",
         "active": true,


### PR DESCRIPTION
### 🏷️ Ticket

![image](https://github.com/user-attachments/assets/effca745-231b-4ff5-8987-d7af67da4ebe)

### test command
`docker compose exec runner python -m aci.cli.aci fuzzy-test-function-execution --function-name GITHUB__CREATE_REPOSITORY --linked-account-owner-id 123 --aci-api-key 21596e302a2dea1955dc45ecd0d2853fb0dc8ecced8b543e96b6c131c5987499 --prompt "Create a new GitHub repository named 'api-test-repo' with description 'Testing the GitHub API integration', make it public and initialize it with a README file"`

### 📸 Screenshots (if applicable)


https://www.notion.so/github-1f18378d6a478085ae09ed6bff9061e9?pvs=4
### ✅ Checklist

- [✅ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [✅ ] I have linked this PR to an issue or a ticket (required)
- [ ✅] I have updated the documentation related to my change if needed
- [✅ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [✅ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to create new GitHub repositories directly through the application. Users can specify repository name, description, privacy settings, initialization options, gitignore template, and license template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->