### PR TITLE
Feat/linked accounts quota

### DIFF
--- a/backend/aci/common/db/crud/linked_accounts.py
+++ b/backend/aci/common/db/crud/linked_accounts.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import distinct, func, select
 from sqlalchemy.orm import Session
 
 from aci.common import validators
@@ -169,5 +169,5 @@ def delete_linked_accounts(db_session: Session, project_id: UUID, app_name: str)
 
 
 def get_total_number_of_unique_linked_account_ids(db_session: Session) -> int:
-    statement = select(LinkedAccount)
-    return len(db_session.execute(statement).scalars().all())
+    statement = select(func.count(distinct(LinkedAccount.id)))
+    return db_session.execute(statement).scalar_one()

--- a/backend/aci/common/db/crud/linked_accounts.py
+++ b/backend/aci/common/db/crud/linked_accounts.py
@@ -166,3 +166,8 @@ def delete_linked_accounts(db_session: Session, project_id: UUID, app_name: str)
         db_session.delete(linked_account)
     db_session.flush()
     return len(linked_accounts_to_delete)
+
+
+def get_total_number_of_unique_linked_account_ids(db_session: Session) -> int:
+    statement = select(LinkedAccount)
+    return len(db_session.execute(statement).scalars().all())

--- a/backend/aci/common/db/crud/linked_accounts.py
+++ b/backend/aci/common/db/crud/linked_accounts.py
@@ -168,6 +168,6 @@ def delete_linked_accounts(db_session: Session, project_id: UUID, app_name: str)
     return len(linked_accounts_to_delete)
 
 
-def get_total_number_of_unique_linked_account_ids(db_session: Session) -> int:
-    statement = select(func.count(distinct(LinkedAccount.id)))
+def get_total_number_of_unique_linked_account_owner_ids(db_session: Session) -> int:
+    statement = select(func.count(distinct(LinkedAccount.linked_account_owner_id)))
     return db_session.execute(statement).scalar_one()

--- a/backend/aci/common/exceptions.py
+++ b/backend/aci/common/exceptions.py
@@ -432,3 +432,14 @@ class OAuth2Error(ACIException):
             message=message,
             error_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+class MaxLinkedAccountsReached(ACIException):
+    """Raised when a project has reached its maximum allowed linked accounts for an app."""
+
+    def __init__(self, message: str | None = None):
+        super().__init__(
+            title="Max linked accounts reached",
+            message=message,
+            error_code=status.HTTP_403_FORBIDDEN,
+        )

--- a/backend/aci/common/exceptions.py
+++ b/backend/aci/common/exceptions.py
@@ -434,12 +434,12 @@ class OAuth2Error(ACIException):
         )
 
 
-class MaxLinkedAccountsReached(ACIException):
-    """Raised when a project has reached its maximum allowed linked accounts for an app."""
+class MaxUniqueLinkedAccountOwnerIdsReached(ACIException):
+    """Raised when an organization has reached its maximum allowed linked accounts for an app."""
 
     def __init__(self, message: str | None = None):
         super().__init__(
-            title="Max linked accounts reached",
+            title="Max unique linked account owner ids reached",
             message=message,
             error_code=status.HTTP_403_FORBIDDEN,
         )

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -114,7 +114,7 @@ def enforce_linked_accounts_creation_quota(
     # Get the linked accounts quota from the plan's features
     max_linked_accounts = plan.features.get("linked_accounts", 0)
 
-    num_linked_accounts = crud.linked_accounts.get_total_number_of_unique_linked_account_ids(
+    num_linked_accounts = crud.linked_accounts.get_total_number_of_unique_linked_account_owner_ids(
         db_session
     )
     if num_linked_accounts >= max_linked_accounts:

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -114,17 +114,17 @@ def enforce_linked_accounts_creation_quota(
     # Get the linked accounts quota from the plan's features
     max_linked_accounts = plan.features.get("linked_accounts", 0)
 
-    linked_accounts = crud.linked_accounts.get_linked_accounts(
-        db_session, project_id, app_name, None
+    num_linked_accounts = crud.linked_accounts.get_total_number_of_unique_linked_account_ids(
+        db_session
     )
-    if len(linked_accounts) >= max_linked_accounts:
+    if num_linked_accounts >= max_linked_accounts:
         logger.error(
             "project has reached maximum linked accounts quota for app",
             extra={
                 "project_id": project_id,
                 "app_name": app_name,
                 "max_linked_accounts": max_linked_accounts,
-                "num_linked_accounts": len(linked_accounts),
+                "num_linked_accounts": num_linked_accounts,
                 "plan": plan.name,
             },
         )

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -11,7 +11,13 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from aci.common.db import crud
-from aci.common.exceptions import MaxAgentsReached, MaxProjectsReached
+from aci.common.exceptions import (
+    MaxAgentsReached,
+    MaxLinkedAccountsReached,
+    MaxProjectsReached,
+    ProjectNotFound,
+    SubscriptionPlanNotFound,
+)
 from aci.common.logging_setup import get_logger
 from aci.server import config
 
@@ -64,3 +70,62 @@ def enforce_agent_creation_quota(db_session: Session, project_id: UUID) -> None:
             },
         )
         raise MaxAgentsReached()
+
+
+def enforce_linked_accounts_creation_quota(
+    db_session: Session, project_id: UUID, app_name: str
+) -> None:
+    """
+    Check and enforce that the project hasn't exceeded its linked accounts creation quota for a specific app.
+    The quota is determined by the organization's current subscription plan.
+
+    Args:
+        db_session: Database session
+        project_id: ID of the project to check
+        app_name: Name of the app to check linked accounts for
+
+    Raises:
+        MaxLinkedAccountsReached: If the project has reached its maximum allowed linked accounts for the app
+        SubscriptionPlanNotFound: If the organization's subscription plan cannot be found
+    """
+    # Get the organization ID from the project
+    project = crud.projects.get_project(db_session, project_id)
+    if not project:
+        logger.error(
+            "project not found",
+            extra={"project_id": project_id},
+        )
+        raise ProjectNotFound(f"Project {project_id} not found")
+    org_id = project.org_id
+
+    # Get the organization's subscription
+    subscription = crud.subscriptions.get_subscription_by_org_id(db_session, org_id)
+    if not subscription:
+        # If no subscription found, use the free plan
+        plan = crud.plans.get_by_name(db_session, "free")
+        if not plan:
+            raise SubscriptionPlanNotFound("Free plan not found")
+    else:
+        # Get the plan from the subscription
+        plan = crud.plans.get_by_id(db_session, subscription.plan_id)
+        if not plan:
+            raise SubscriptionPlanNotFound(f"Plan {subscription.plan_id} not found")
+
+    # Get the linked accounts quota from the plan's features
+    max_linked_accounts = plan.features.get("linked_accounts", 0)
+
+    linked_accounts = crud.linked_accounts.get_linked_accounts(
+        db_session, project_id, app_name, None
+    )
+    if len(linked_accounts) >= max_linked_accounts:
+        logger.error(
+            "project has reached maximum linked accounts quota for app",
+            extra={
+                "project_id": project_id,
+                "app_name": app_name,
+                "max_linked_accounts": max_linked_accounts,
+                "num_linked_accounts": len(linked_accounts),
+                "plan": plan.name,
+            },
+        )
+        raise MaxLinkedAccountsReached()

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -75,8 +75,8 @@ def enforce_linked_accounts_creation_quota(
     db_session: Session, org_id: UUID, linked_account_owner_id: str
 ) -> None:
     """
-    Check and enforce that the organization hasn't exceeded its unique linked account owner ids
-    quota, which is determined by the organization's current subscription plan.
+    Check and enforce that the organization doesn't have a unique_account_owner_id exceeding the
+    quota determined by the organization's current subscription plan.
 
     Args:
         db_session: Database session

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -13,9 +13,8 @@ from sqlalchemy.orm import Session
 from aci.common.db import crud
 from aci.common.exceptions import (
     MaxAgentsReached,
-    MaxLinkedAccountsReached,
     MaxProjectsReached,
-    ProjectNotFound,
+    MaxUniqueLinkedAccountOwnerIdsReached,
     SubscriptionPlanNotFound,
 )
 from aci.common.logging_setup import get_logger
@@ -73,30 +72,28 @@ def enforce_agent_creation_quota(db_session: Session, project_id: UUID) -> None:
 
 
 def enforce_linked_accounts_creation_quota(
-    db_session: Session, project_id: UUID, app_name: str
+    db_session: Session, org_id: UUID, linked_account_owner_id: str
 ) -> None:
     """
-    Check and enforce that the project hasn't exceeded its linked accounts creation quota for a specific app.
-    The quota is determined by the organization's current subscription plan.
+    Check and enforce that the organization hasn't exceeded its unique linked account owner ids
+    quota, which is determined by the organization's current subscription plan.
 
     Args:
         db_session: Database session
-        project_id: ID of the project to check
-        app_name: Name of the app to check linked accounts for
+        org_id: ID of the organization to check
+        linked_account_owner_id: ID of the linked account owner to check
 
     Raises:
-        MaxLinkedAccountsReached: If the project has reached its maximum allowed linked accounts for the app
+        MaxUniqueLinkedAccountOwnerIdsReached: If the organization has reached its maximum
+        allowed unique linked account owner ids
         SubscriptionPlanNotFound: If the organization's subscription plan cannot be found
     """
-    # Get the organization ID from the project
-    project = crud.projects.get_project(db_session, project_id)
-    if not project:
-        logger.error(
-            "project not found",
-            extra={"project_id": project_id},
-        )
-        raise ProjectNotFound(f"Project {project_id} not found")
-    org_id = project.org_id
+    if crud.linked_accounts.linked_account_owner_id_exists_in_org(
+        db_session, org_id, linked_account_owner_id
+    ):
+        # If the linked account owner id already exists in the organization, linking this account
+        # will not increase the total number of unique linked account owner ids or exceed the quota.
+        return
 
     # Get the organization's subscription
     subscription = crud.subscriptions.get_subscription_by_org_id(db_session, org_id)
@@ -112,20 +109,20 @@ def enforce_linked_accounts_creation_quota(
             raise SubscriptionPlanNotFound(f"Plan {subscription.plan_id} not found")
 
     # Get the linked accounts quota from the plan's features
-    max_linked_accounts = plan.features.get("linked_accounts", 0)
+    max_unique_linked_account_owner_ids = plan.features.get("linked_accounts", 0)
 
-    num_linked_accounts = crud.linked_accounts.get_total_number_of_unique_linked_account_owner_ids(
-        db_session, org_id
+    num_unique_linked_account_owner_ids = (
+        crud.linked_accounts.get_total_number_of_unique_linked_account_owner_ids(db_session, org_id)
     )
-    if num_linked_accounts >= max_linked_accounts:
+
+    if num_unique_linked_account_owner_ids >= max_unique_linked_account_owner_ids:
         logger.error(
-            "project has reached maximum linked accounts quota for app",
+            "organization has reached maximum unique linked account owner ids quota for the current plan",
             extra={
-                "project_id": project_id,
-                "app_name": app_name,
-                "max_linked_accounts": max_linked_accounts,
-                "num_linked_accounts": num_linked_accounts,
+                "org_id": org_id,
+                "max_unique_linked_account_owner_ids": max_unique_linked_account_owner_ids,
+                "num_unique_linked_account_owner_ids": num_unique_linked_account_owner_ids,
                 "plan": plan.name,
             },
         )
-        raise MaxLinkedAccountsReached()
+        raise MaxUniqueLinkedAccountOwnerIdsReached()

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -115,7 +115,7 @@ def enforce_linked_accounts_creation_quota(
     max_linked_accounts = plan.features.get("linked_accounts", 0)
 
     num_linked_accounts = crud.linked_accounts.get_total_number_of_unique_linked_account_owner_ids(
-        db_session
+        db_session, org_id
     )
     if num_linked_accounts >= max_linked_accounts:
         logger.error(

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -33,7 +33,7 @@ from aci.common.schemas.security_scheme import (
     APIKeySchemeCredentials,
     NoAuthSchemeCredentials,
 )
-from aci.server import config
+from aci.server import config, quota_manager
 from aci.server import dependencies as deps
 from aci.server import security_credentials_manager as scm
 from aci.server.oauth2_manager import OAuth2Manager
@@ -137,6 +137,11 @@ async def link_account_with_aci_default_credentials(
             f"linked account with linked_account_owner_id={body.linked_account_owner_id} already exists for app={body.app_name}"
         )
     else:
+        # Enforce linked accounts quota before creating new account
+        quota_manager.enforce_linked_accounts_creation_quota(
+            context.db_session, context.project.id, body.app_name
+        )
+
         logger.info(
             "creating linked account with ACI default credentials",
             extra={
@@ -211,6 +216,11 @@ async def link_account_with_no_auth(
             f"linked account with linked_account_owner_id={body.linked_account_owner_id} already exists for app={body.app_name}"
         )
     else:
+        # Enforce linked accounts quota before creating new account
+        quota_manager.enforce_linked_accounts_creation_quota(
+            context.db_session, context.project.id, body.app_name
+        )
+
         logger.info(
             "creating no_auth linked account",
             extra={
@@ -299,6 +309,11 @@ async def link_account_with_api_key(
             f"linked account with linked_account_owner_id={body.linked_account_owner_id} already exists for app={body.app_name}"
         )
     else:
+        # Enforce linked accounts quota before creating new account
+        quota_manager.enforce_linked_accounts_creation_quota(
+            context.db_session, context.project.id, body.app_name
+        )
+
         logger.info(
             "creating api_key linked account",
             extra={
@@ -561,6 +576,11 @@ async def linked_accounts_oauth2_callback(
             db_session, linked_account, security_credentials
         )
     else:
+        # Enforce linked accounts quota before creating new account
+        quota_manager.enforce_linked_accounts_creation_quota(
+            db_session, state.project_id, state.app_name
+        )
+
         logger.info(
             "creating oauth2 linked account",
             extra={

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -139,7 +139,7 @@ async def link_account_with_aci_default_credentials(
     else:
         # Enforce linked accounts quota before creating new account
         quota_manager.enforce_linked_accounts_creation_quota(
-            context.db_session, context.project.id, body.app_name
+            context.db_session, context.project.org_id, body.linked_account_owner_id
         )
 
         logger.info(
@@ -218,7 +218,7 @@ async def link_account_with_no_auth(
     else:
         # Enforce linked accounts quota before creating new account
         quota_manager.enforce_linked_accounts_creation_quota(
-            context.db_session, context.project.id, body.app_name
+            context.db_session, context.project.org_id, body.linked_account_owner_id
         )
 
         logger.info(
@@ -311,7 +311,7 @@ async def link_account_with_api_key(
     else:
         # Enforce linked accounts quota before creating new account
         quota_manager.enforce_linked_accounts_creation_quota(
-            context.db_session, context.project.id, body.app_name
+            context.db_session, context.project.org_id, body.linked_account_owner_id
         )
 
         logger.info(
@@ -377,6 +377,11 @@ async def link_oauth2_account(
             f"the security_scheme configured in app={query_params.app_name} is "
             f"{app_configuration.security_scheme}, not OAuth2"
         )
+
+    # Enforce linked accounts quota before creating new account
+    quota_manager.enforce_linked_accounts_creation_quota(
+        context.db_session, context.project.org_id, query_params.linked_account_owner_id
+    )
 
     oauth2_scheme = scm.get_app_configuration_oauth2_scheme(
         app_configuration.app, app_configuration
@@ -578,7 +583,7 @@ async def linked_accounts_oauth2_callback(
     else:
         # Enforce linked accounts quota before creating new account
         quota_manager.enforce_linked_accounts_creation_quota(
-            db_session, state.project_id, state.app_name
+            db_session, state.project_id, state.linked_account_owner_id
         )
 
         logger.info(

--- a/backend/aci/server/tests/conftest.py
+++ b/backend/aci/server/tests/conftest.py
@@ -746,9 +746,6 @@ def dummy_linked_account_no_auth_mock_app_connector_project_1(
 
 @pytest.fixture(scope="function")
 def free_plan(db_session: Session) -> Plan:
-    """
-    Creates a free plan fixture with standard free tier features.
-    """
     plan = crud.plans.create(
         db=db_session,
         name="free",
@@ -756,7 +753,7 @@ def free_plan(db_session: Session) -> Plan:
         stripe_monthly_price_id="price_FREE_monthly_placeholder",
         stripe_yearly_price_id="price_FREE_yearly_placeholder",
         features=PlanFeatures(
-            linked_accounts=1,
+            linked_accounts=3,
             api_calls_monthly=1000,
             agent_credentials=5,
             developer_seats=1,

--- a/backend/aci/server/tests/conftest.py
+++ b/backend/aci/server/tests/conftest.py
@@ -15,7 +15,9 @@ from sqlalchemy import inspect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import Session
 
+from aci.common.db.sql_models import Plan
 from aci.common.enums import OrganizationRole
+from aci.common.schemas.plans import PlanFeatures
 from aci.server import acl
 
 # override the rate limit to a high number for testing before importing aci modules
@@ -740,3 +742,28 @@ def dummy_linked_account_no_auth_mock_app_connector_project_1(
     )
     db_session.commit()
     yield dummy_linked_account_no_auth_mock_app_connector_project_1
+
+
+@pytest.fixture(scope="function")
+def free_plan(db_session: Session) -> Plan:
+    """
+    Creates a free plan fixture with standard free tier features.
+    """
+    plan = crud.plans.create(
+        db=db_session,
+        name="free",
+        stripe_product_id="prod_FREE_placeholder",
+        stripe_monthly_price_id="price_FREE_monthly_placeholder",
+        stripe_yearly_price_id="price_FREE_yearly_placeholder",
+        features=PlanFeatures(
+            linked_accounts=1,
+            api_calls_monthly=1000,
+            agent_credentials=5,
+            developer_seats=1,
+            custom_oauth=False,
+            log_retention_days=7,
+        ),
+        is_public=True,
+    )
+    db_session.commit()
+    return plan

--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
@@ -21,7 +21,7 @@ def test_linked_accounts_quota(
         stripe_monthly_price_id="price_FREE_monthly_placeholder",
         stripe_yearly_price_id="price_FREE_yearly_placeholder",
         features=PlanFeatures(
-            linked_accounts=1,
+            linked_accounts=2,
             api_calls_monthly=1000,
             agent_credentials=5,
             developer_seats=1,
@@ -45,7 +45,7 @@ def test_linked_accounts_quota(
     )
     assert response.status_code == status.HTTP_200_OK
 
-    # Try to create second linked account (should fail due to quota)
+    # Create second linked account (should also succeed)
     body2 = LinkedAccountNoAuthCreate(
         app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
         linked_account_owner_id="test_linked_accounts_quota_2",
@@ -53,6 +53,18 @@ def test_linked_accounts_quota(
     response = test_client.post(
         f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
         json=body2.model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Try to create third linked account (should fail due to quota)
+    body3 = LinkedAccountNoAuthCreate(
+        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+        linked_account_owner_id="test_linked_accounts_quota_3",
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+        json=body3.model_dump(mode="json", exclude_none=True),
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
@@ -1,0 +1,59 @@
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from aci.common.db.sql_models import Plan
+from aci.common.schemas.app_configurations import AppConfigurationPublic
+from aci.common.schemas.linked_accounts import LinkedAccountNoAuthCreate
+from aci.common.schemas.plans import PlanFeatures
+from aci.server import config
+
+
+def test_linked_accounts_quota(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_app_configuration_no_auth_mock_app_connector_project_1: AppConfigurationPublic,
+    db_session: Session,
+) -> None:
+    plan = Plan(
+        name="free",
+        stripe_product_id="prod_FREE_placeholder",
+        stripe_monthly_price_id="price_FREE_monthly_placeholder",
+        stripe_yearly_price_id="price_FREE_yearly_placeholder",
+        features=PlanFeatures(
+            linked_accounts=1,
+            api_calls_monthly=1000,
+            agent_credentials=5,
+            developer_seats=1,
+            custom_oauth=False,
+            log_retention_days=7,
+        ).model_dump(),
+        is_public=True,
+    )
+    db_session.add(plan)
+    db_session.commit()
+
+    # Create first linked account (should succeed)
+    body1 = LinkedAccountNoAuthCreate(
+        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+        linked_account_owner_id="test_linked_accounts_quota_1",
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+        json=body1.model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Try to create second linked account (should fail due to quota)
+    body2 = LinkedAccountNoAuthCreate(
+        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+        linked_account_owner_id="test_linked_accounts_quota_2",
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+        json=body2.model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Max linked accounts reached" in str(response.json()["error"])

--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
@@ -3,37 +3,148 @@ from fastapi.testclient import TestClient
 
 from aci.common.db.sql_models import Plan
 from aci.common.schemas.app_configurations import AppConfigurationPublic
-from aci.common.schemas.linked_accounts import LinkedAccountNoAuthCreate
+from aci.common.schemas.linked_accounts import (
+    LinkedAccountAPIKeyCreate,
+    LinkedAccountNoAuthCreate,
+    LinkedAccountOAuth2Create,
+)
 from aci.server import config
 
 
-def test_linked_accounts_quota(
+def test_linked_accounts_quota_for_a_single_project_in_an_org(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_app_configuration_no_auth_mock_app_connector_project_1: AppConfigurationPublic,
+    dummy_app_configuration_api_key_aci_test_project_1: AppConfigurationPublic,
+    dummy_app_configuration_oauth2_google_project_1: AppConfigurationPublic,
     free_plan: Plan,
 ) -> None:
-    # Create first linked account (should succeed)
-    body1 = LinkedAccountNoAuthCreate(
-        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
-        linked_account_owner_id="test_linked_accounts_quota_1",
+    # Given: User has already created the max number of unique linked account owner ids
+    for i in range(free_plan.features["linked_accounts"]):
+        linked_account_owner_id = f"test_linked_accounts_quota_{i}"
+        body = LinkedAccountNoAuthCreate(
+            app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+            linked_account_owner_id=linked_account_owner_id,
+        )
+        response = test_client.post(
+            f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+            json=body.model_dump(mode="json", exclude_none=True),
+            headers={"x-api-key": dummy_api_key_1},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    # Then: User can still create a new linked account with the same owner id in a
+    # different app
+    existing_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] - 1}"
     )
     response = test_client.post(
-        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
-        json=body1.model_dump(mode="json", exclude_none=True),
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_aci_test_project_1.app_name,
+            linked_account_owner_id=existing_linked_account_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_200_OK
 
-    # Try to create third linked account (should fail due to quota)
-    body2 = LinkedAccountNoAuthCreate(
-        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
-        linked_account_owner_id="test_linked_accounts_quota_3",
+    # Then: User cannot create a new linked account with a new owner id in no-auth app
+    new_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] + 1}"
     )
     response = test_client.post(
         f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
-        json=body2.model_dump(mode="json", exclude_none=True),
+        json=LinkedAccountNoAuthCreate(
+            app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+            linked_account_owner_id=new_linked_account_owner_id,
+        ).model_dump(mode="json", exclude_none=True),
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert "Max linked accounts reached" in str(response.json()["error"])
+
+    # Then: User cannot create a new linked account with a new owner id in api-key app
+    new_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] + 2}"
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_aci_test_project_1.app_name,
+            linked_account_owner_id=new_linked_account_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Then: User cannot create a new linked account with a new owner id in oauth2 app
+    new_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] + 3}"
+    )
+    response = test_client.get(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/oauth2",
+        params=LinkedAccountOAuth2Create(
+            app_name=dummy_app_configuration_oauth2_google_project_1.app_name,
+            linked_account_owner_id=new_linked_account_owner_id,
+            after_oauth2_link_redirect_url="https://example.com",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_linked_accounts_quota_for_multiple_projects_in_an_org(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_app_configuration_api_key_github_project_1: AppConfigurationPublic,
+    dummy_api_key_2: str,
+    dummy_app_configuration_api_key_github_project_2: AppConfigurationPublic,
+    free_plan: Plan,
+) -> None:
+    # Given: User has already created the max number of unique linked account owner ids
+    # in project 1
+    for i in range(free_plan.features["linked_accounts"]):
+        linked_account_owner_id = f"test_linked_accounts_quota_{i}"
+        body = LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_github_project_1.app_name,
+            linked_account_owner_id=linked_account_owner_id,
+            api_key="aci_api_key",
+        )
+        response = test_client.post(
+            f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+            json=body.model_dump(mode="json", exclude_none=True),
+            headers={"x-api-key": dummy_api_key_1},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    # Then: User can still create a new linked account with an existing owner id in
+    # project 2
+    existing_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] - 1}"
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_github_project_2.app_name,
+            linked_account_owner_id=existing_linked_account_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_2},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Then: User cannot create a new linked account with a new owner id in project 2
+    new_linked_account_owner_id = (
+        f"test_linked_accounts_quota_{free_plan.features['linked_accounts'] + 1}"
+    )
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_github_project_2.app_name,
+            linked_account_owner_id=new_linked_account_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_2},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
@@ -1,11 +1,9 @@
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
 
 from aci.common.db.sql_models import Plan
 from aci.common.schemas.app_configurations import AppConfigurationPublic
 from aci.common.schemas.linked_accounts import LinkedAccountNoAuthCreate
-from aci.common.schemas.plans import PlanFeatures
 from aci.server import config
 
 
@@ -13,26 +11,8 @@ def test_linked_accounts_quota(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_app_configuration_no_auth_mock_app_connector_project_1: AppConfigurationPublic,
-    db_session: Session,
+    free_plan: Plan,
 ) -> None:
-    plan = Plan(
-        name="free",
-        stripe_product_id="prod_FREE_placeholder",
-        stripe_monthly_price_id="price_FREE_monthly_placeholder",
-        stripe_yearly_price_id="price_FREE_yearly_placeholder",
-        features=PlanFeatures(
-            linked_accounts=2,
-            api_calls_monthly=1000,
-            agent_credentials=5,
-            developer_seats=1,
-            custom_oauth=False,
-            log_retention_days=7,
-        ).model_dump(),
-        is_public=True,
-    )
-    db_session.add(plan)
-    db_session.commit()
-
     # Create first linked account (should succeed)
     body1 = LinkedAccountNoAuthCreate(
         app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
@@ -45,26 +25,14 @@ def test_linked_accounts_quota(
     )
     assert response.status_code == status.HTTP_200_OK
 
-    # Create second linked account (should also succeed)
-    body2 = LinkedAccountNoAuthCreate(
-        app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
-        linked_account_owner_id="test_linked_accounts_quota_2",
-    )
-    response = test_client.post(
-        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
-        json=body2.model_dump(mode="json", exclude_none=True),
-        headers={"x-api-key": dummy_api_key_1},
-    )
-    assert response.status_code == status.HTTP_200_OK
-
     # Try to create third linked account (should fail due to quota)
-    body3 = LinkedAccountNoAuthCreate(
+    body2 = LinkedAccountNoAuthCreate(
         app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
         linked_account_owner_id="test_linked_accounts_quota_3",
     )
     response = test_client.post(
         f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
-        json=body3.model_dump(mode="json", exclude_none=True),
+        json=body2.model_dump(mode="json", exclude_none=True),
         headers={"x-api-key": dummy_api_key_1},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/Enforce-Rate-Limiting-for-Pricing-1f18378d6a4780e39d2bee63d33f38fa?pvs=4

### 📝 Description

Enforce quota for linked account owner ids

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enforced linked account creation limits per organization based on subscription plans.
  - Added clear error notifications when the maximum number of unique linked account owner IDs is reached.
- **Tests**
  - Added tests to verify linked account quota enforcement across multiple projects and app configurations within an organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->