### PR TITLE
Integration update: GMAIL__MESSAGES_GET function update

### DIFF
--- a/backend/apps/gmail/functions.json
+++ b/backend/apps/gmail/functions.json
@@ -51,6 +51,94 @@
         }
     },
     {
+        "name": "GMAIL__MESSAGES_GET",
+        "description": "Retrieves and decodes an email message from Gmail",
+        "tags": ["email", "messages"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "connector",
+        "protocol_data": {},
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "message_id": {
+                    "type": "string",
+                    "description": "The ID of the message to retrieve"
+                },
+                "user_id": {
+                    "type": "string",
+                    "description": "The user's email address. The special value me can be used to indicate the authenticated user.",
+                    "default": "me"
+                },
+                "format": {
+                    "type": "string",
+                    "description": "The format to return the message in",
+                    "enum": ["full", "metadata", "minimal", "raw"],
+                    "default": "full"
+                }
+            },
+            "required": ["message_id"],
+            "visible": ["message_id", "user_id", "format"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GMAIL__MESSAGES_GET_RAW",
+        "description": "Gets the specified message in raw format with base64 encoded content",
+        "tags": ["email", "messages"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/users/me/messages/{id}",
+            "server_url": "https://gmail.googleapis.com/gmail/v1"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "The ID of the message to retrieve"
+                        }
+                    },
+                    "required": ["id"],
+                    "visible": ["id"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "format": {
+                            "type": "string",
+                            "description": "The format to return the message in",
+                            "enum": ["full", "metadata", "minimal", "raw"],
+                            "default": "full"
+                        },
+                        "metadataHeaders": {
+                            "type": "array",
+                            "description": "When given and format is metadata, only include headers specified",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": ["format"],
+                    "visible": ["format", "metadataHeaders"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path", "query"],
+            "visible": ["path", "query"],
+            "additionalProperties": false
+        }
+    },
+    {
         "name": "GMAIL__MESSAGES_LIST",
         "description": "Lists the messages in the user's mailbox",
         "tags": ["email", "messages"],
@@ -104,62 +192,6 @@
             },
             "required": [],
             "visible": ["query"],
-            "additionalProperties": false
-        }
-    },
-    {
-        "name": "GMAIL__MESSAGES_GET",
-        "description": "Gets the specified message",
-        "tags": ["email", "messages"],
-        "visibility": "public",
-        "active": true,
-        "protocol": "rest",
-        "protocol_data": {
-            "method": "GET",
-            "path": "/users/me/messages/{id}",
-            "server_url": "https://gmail.googleapis.com/gmail/v1"
-        },
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "object",
-                    "description": "Path parameters",
-                    "properties": {
-                        "id": {
-                            "type": "string",
-                            "description": "The ID of the message to retrieve"
-                        }
-                    },
-                    "required": ["id"],
-                    "visible": ["id"],
-                    "additionalProperties": false
-                },
-                "query": {
-                    "type": "object",
-                    "description": "Query parameters",
-                    "properties": {
-                        "format": {
-                            "type": "string",
-                            "description": "The format to return the message in",
-                            "enum": ["full", "metadata", "minimal", "raw"],
-                            "default": "full"
-                        },
-                        "metadataHeaders": {
-                            "type": "array",
-                            "description": "When given and format is metadata, only include headers specified",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "required": ["format"],
-                    "visible": ["format", "metadataHeaders"],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["path", "query"],
-            "visible": ["path", "query"],
             "additionalProperties": false
         }
     },


### PR DESCRIPTION


### 🏷️ Ticket

N/A

### 📝 Description

This PR enhances the Gmail connector functionality by:

1. Adding a `messages_get` method to the Gmail connector class that retrieves and automatically decodes base64-encoded email content.
2. Implementing proper handling of email parts and headers extraction.
3. Exposing the function as `GMAIL__MESSAGES_GET` through our API.
4. Renaming the original raw API endpoint to `GMAIL__MESSAGES_GET_RAW` for clarity.

Here is the fuzzy test prompt to test the functions:

#### Test `GMAIL__MESSAGES_GET`:
```bash
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GMAIL__MESSAGES_GET \
  --linked-account-owner-id 2463d857-cf44-464d-8db5-c687a795bf99 \
  --aci-api-key 251e318625ff383f1ec0f440e4525e5f7a36a6325b084ab0665a711f787970df \
  --prompt "Get the email with ID '196c725a76f24e0e' from my Gmail inbox."
````

#### Test `GMAIL__MESSAGES_GET_RAW`:

```bash
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GMAIL__MESSAGES_GET_RAW \
  --linked-account-owner-id 2463d857-cf44-464d-8db5-c687a795bf99 \
  --aci-api-key 251e318625ff383f1ec0f440e4525e5f7a36a6325b084ab0665a711f787970df \
  --prompt "Get the email with ID '196c725a76f24e0e' from my Gmail inbox."
```

* When using the `GMAIL__MESSAGES_GET` function, you receive the base64-decoded version of the email, which usually includes HTML, making it easy for LLMs to read.
* When using the `GMAIL__MESSAGES_GET_RAW` function, you still receive the base64-encoded raw email data, maintaining the original format.

### 🎥 Demo (if applicable)

N/A

### 📸 Screenshots (if applicable)

Execution Result for `GMAIL__MESSAGES_GET`
![image](https://github.com/user-attachments/assets/685f9e26-5dfd-4880-81ca-f9aa1546a57a)

Execution Result for `GMAIL__MESSAGES_GET` (Email content)
![image](https://github.com/user-attachments/assets/2c0e7efd-7e0f-4a09-bb83-11d40fd242c3)

Proof that LLM can read the email content from `GMAIL__MESSAGES_GET`
![image](https://github.com/user-attachments/assets/9b03cf6f-509b-40ba-9736-3da8be091818)

Execution Result for `GMAIL__MESSAGES_GET_RAW`
![image](https://github.com/user-attachments/assets/9b399bd8-be93-44ea-8dbd-01d62dec002d)


### ✅ Checklist

* [x] I have signed the [[Contributor License Agreement](https://chatgpt.com/c/6822b0f6-03e4-8005-a6cd-225803cc9664)]() (CLA) and read the [[contributing guide](https://chatgpt.com/CONTRIBUTING.md)](./../CONTRIBUTING.md) (required)
* [ ] I have linked this PR to an issue or a ticket (required)
* [ ] I have updated the documentation related to my change if needed
* [x] I have updated the tests accordingly (required for a bug fix or a new feature)
* [x] All checks on CI passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve and decode individual Gmail messages, providing structured access to message content and headers.

- **Improvements**
  - Refined Gmail message-related functions: message listing and retrieval are now clearly separated, with dedicated functions for listing, decoded retrieval, and raw retrieval.
  - Updated function parameters for more precise control when fetching Gmail messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->