### PR TITLE
feat: add inline message callout for ACI.dev OAuth2 App

### DIFF
--- a/frontend/src/components/apps/configure-app/configure-app-step.tsx
+++ b/frontend/src/components/apps/configure-app/configure-app-step.tsx
@@ -246,6 +246,23 @@ export function ConfigureAppStep({
             </div>
           )}
 
+          {currentSecurityScheme === "oauth2" && useACIDevOAuth2 && (
+            <div className="bg-yellow-100 border border-yellow-300 p-3 rounded flex items-start gap-2">
+              {/* <BsQuestionCircle className="mt-1 h-4 w-4 text-yellow-700" /> */}
+              <p className="text-sm text-yellow-900">
+                We <strong>recommend</strong> using your own OAuth2 app in
+                production.
+                {/* <a
+                  href="https://www.aci.dev/docs/core-concepts/linked-account#linking-oauth2-account"
+                  target="_blank"
+                  className="underline text-blue-700"
+                >
+                  See documentation →
+                </a> */}
+              </p>
+            </div>
+          )}
+
           <DialogFooter>
             <Button type="submit" disabled={isLoading || !isFormValid()}>
               {isLoading ? "Confirming..." : "Confirm"}


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Detailed Description

This update introduces an inline callout message that appears when the "Use ACI.dev OAuth2 App" switch is enabled. The callout is a visually distinct yellow notification area that informs users about the recommendation to use their own OAuth2 app in production for better access control and security.

* The callout only appears when the switch is set to `true` use aci.dev OAuth2 and the authentication method is set to `OAuth2`.
* The message is styled with a yellow background and border to ensure visibility

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d6b70560-a5f8-4a08-b41a-81f5badbf1b1)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an informational warning box that appears when configuring an app with the OAuth2 security scheme using the ACI.dev OAuth2 app, recommending the use of a custom OAuth2 app in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->