### PR TITLE
refactor: unify usepppconfig hooks by tanstack query 

### DIFF
--- a/frontend/src/app/appconfigs/page.tsx
+++ b/frontend/src/app/appconfigs/page.tsx
@@ -1,22 +1,19 @@
 "use client";
 
-// import { Button } from "@/components/ui/button";
-import { useCallback, useEffect, useState } from "react";
-// import { GoPlus } from "react-icons/go";
-import { AppConfig } from "@/lib/types/appconfig";
+import { useEffect, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 import { getApiKey } from "@/lib/api/util";
-import { getAllAppConfigs } from "@/lib/api/appconfig";
 import { App } from "@/lib/types/app";
 import { getAppLinkedAccounts } from "@/lib/api/linkedaccount";
 import { useMetaInfo } from "@/components/context/metainfo";
 import { useAppConfigsTableColumns } from "@/components/appconfig/useAppConfigsTableColumns";
 import { EnhancedDataTable } from "@/components/ui-extensions/enhanced-data-table/data-table";
 import { useApps } from "@/hooks/use-app";
+import { useAppConfigs } from "@/hooks/use-app-config";
+
 export default function AppConfigPage() {
-  const [appConfigs, setAppConfigs] = useState<AppConfig[]>([]);
-  const [appsMap, setAppsMap] = useState<Record<string, App>>({});
-  const { data: apps } = useApps();
+  const { data: appConfigs = [], isLoading: configsLoading } = useAppConfigs();
+  const { data: apps = [] } = useApps();
   const [linkedAccountsCountMap, setLinkedAccountsCountMap] = useState<
     Record<string, number>
   >({});
@@ -24,50 +21,44 @@ export default function AppConfigPage() {
 
   const { activeProject } = useMetaInfo();
 
-  const loadAllData = useCallback(async () => {
-    if (!apps) {
-      return;
-    }
-
-    try {
-      const apiKey = getApiKey(activeProject);
-      const configs = await getAllAppConfigs(apiKey);
-
-      const appsMapData = apps.reduce(
-        (acc, app) => {
-          acc[app.name] = app;
-          return acc;
-        },
-        {} as Record<string, App>,
-      );
-
-      const linkedAccountsData = await Promise.all(
-        configs.map(async (config) => {
-          const linkedAccounts = await getAppLinkedAccounts(
-            config.app_name,
-            apiKey,
-          );
-          return [config.app_name, linkedAccounts.length];
-        }),
-      );
-
-      setAppsMap(appsMapData);
-      setAppConfigs(configs);
-      setLinkedAccountsCountMap(Object.fromEntries(linkedAccountsData));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [activeProject, apps]);
+  const appsMap = apps.reduce(
+    (acc, app) => {
+      acc[app.name] = app;
+      return acc;
+    },
+    {} as Record<string, App>,
+  );
 
   useEffect(() => {
-    loadAllData();
-  }, [loadAllData]);
+    async function fetchLinkedAccounts() {
+      try {
+        if (!appConfigs.length) return;
+        const apiKey = getApiKey(activeProject);
+        const linkedAccountsData = await Promise.all(
+          appConfigs.map(async (config) => {
+            const linkedAccounts = await getAppLinkedAccounts(
+              config.app_name,
+              apiKey,
+            );
+            return [config.app_name, linkedAccounts.length];
+          }),
+        );
+
+        setLinkedAccountsCountMap(Object.fromEntries(linkedAccountsData));
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchLinkedAccounts();
+  }, [appConfigs, activeProject]);
 
   const appConfigsColumns = useAppConfigsTableColumns({
     linkedAccountsCountMap,
     appsMap,
-    updateAppConfigs: loadAllData,
   });
+
+  const isPageLoading = isLoading || configsLoading;
 
   return (
     <div>
@@ -83,7 +74,7 @@ export default function AppConfigPage() {
       <Separator />
 
       <div className="m-4">
-        {isLoading && (
+        {isPageLoading && (
           <div className="flex items-center justify-center p-8">
             <div className="flex flex-col items-center space-y-4">
               <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
@@ -91,7 +82,7 @@ export default function AppConfigPage() {
             </div>
           </div>
         )}
-        {!isLoading && (
+        {!isPageLoading && (
           <EnhancedDataTable
             data={appConfigs}
             columns={appConfigsColumns}

--- a/frontend/src/app/appconfigs/page.tsx
+++ b/frontend/src/app/appconfigs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Separator } from "@/components/ui/separator";
 import { getApiKey } from "@/lib/api/util";
 import { App } from "@/lib/types/app";
@@ -21,12 +21,16 @@ export default function AppConfigPage() {
 
   const { activeProject } = useMetaInfo();
 
-  const appsMap = apps.reduce(
-    (acc, app) => {
-      acc[app.name] = app;
-      return acc;
-    },
-    {} as Record<string, App>,
+  const appsMap = useMemo(
+    () =>
+      apps.reduce(
+        (acc, app) => {
+          acc[app.name] = app;
+          return acc;
+        },
+        {} as Record<string, App>,
+      ),
+    [apps],
   );
 
   useEffect(() => {

--- a/frontend/src/app/appconfigs/page.tsx
+++ b/frontend/src/app/appconfigs/page.tsx
@@ -12,7 +12,8 @@ import { useApps } from "@/hooks/use-app";
 import { useAppConfigs } from "@/hooks/use-app-config";
 
 export default function AppConfigPage() {
-  const { data: appConfigs = [], isLoading: configsLoading } = useAppConfigs();
+  const { data: appConfigs = [], isPending: isConfigsPending } =
+    useAppConfigs();
   const { data: apps = [] } = useApps();
   const [linkedAccountsCountMap, setLinkedAccountsCountMap] = useState<
     Record<string, number>
@@ -62,7 +63,7 @@ export default function AppConfigPage() {
     appsMap,
   });
 
-  const isPageLoading = isLoading || configsLoading;
+  const isPageLoading = isLoading || isConfigsPending;
 
   return (
     <div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -23,7 +23,25 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      // silent refresh settings
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchInterval: 60_000,
+      refetchIntervalInBackground: true,
+
+      // SWR
+      staleTime: 5 * 60_000,
+      gcTime: 15 * 60_000,
+
+      // cache placeholder data
+      placeholderData: (prev: unknown) => prev,
+    },
+  },
+});
 
 export default function RootLayout({
   children,

--- a/frontend/src/hooks/use-app-config.tsx
+++ b/frontend/src/hooks/use-app-config.tsx
@@ -1,0 +1,115 @@
+// hooks/use-app-configs.tsx
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getAllAppConfigs,
+  createAppConfig,
+  updateAppConfig,
+  deleteAppConfig,
+  getAppConfig,
+} from "@/lib/api/appconfig";
+import { useMetaInfo } from "@/components/context/metainfo";
+import { getApiKey } from "@/lib/api/util";
+import { AppConfig } from "@/lib/types/appconfig";
+
+export const useAppConfigs = () => {
+  const { activeProject } = useMetaInfo();
+  const apiKey = getApiKey(activeProject);
+
+  return useQuery<AppConfig[], Error>({
+    queryKey: ["appconfigs"],
+    queryFn: () => getAllAppConfigs(apiKey),
+    enabled: !!apiKey,
+
+    // silent refresh settings
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: true,
+
+    // SWR
+    staleTime: 5 * 60_000,
+    gcTime: 15 * 60_000,
+
+    // cache placeholder data
+    placeholderData: (prev) => prev,
+  });
+};
+
+export const useAppConfig = (appName: string) => {
+  const { activeProject } = useMetaInfo();
+  const apiKey = getApiKey(activeProject);
+
+  return useQuery<AppConfig | null, Error>({
+    queryKey: ["appconfig", appName],
+    queryFn: () => getAppConfig(appName, apiKey),
+    enabled: !!apiKey && !!appName,
+  });
+};
+
+type CreateAppConfigParams = {
+  app_name: string;
+  security_scheme: string;
+  security_scheme_overrides?: {
+    oauth2?: {
+      client_id: string;
+      client_secret: string;
+    } | null;
+  };
+};
+
+export const useCreateAppConfig = () => {
+  const queryClient = useQueryClient();
+  const { activeProject } = useMetaInfo();
+  const apiKey = getApiKey(activeProject);
+
+  return useMutation<AppConfig, Error, CreateAppConfigParams>({
+    mutationFn: (params) =>
+      createAppConfig(
+        params.app_name,
+        params.security_scheme,
+        apiKey,
+        params.security_scheme_overrides,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+    },
+  });
+};
+
+type UpdateAppConfigParams = {
+  app_name: string;
+  enabled: boolean;
+};
+
+export const useUpdateAppConfig = () => {
+  const queryClient = useQueryClient();
+  const { activeProject } = useMetaInfo();
+  const apiKey = getApiKey(activeProject);
+
+  return useMutation<AppConfig, Error, UpdateAppConfigParams>({
+    mutationFn: (params) =>
+      updateAppConfig(params.app_name, params.enabled, apiKey),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+      // The current page may only use the update of a single data item when updating
+      queryClient.invalidateQueries({
+        queryKey: ["appconfig", variables.app_name],
+      });
+    },
+  });
+};
+
+export const useDeleteAppConfig = () => {
+  const queryClient = useQueryClient();
+  const { activeProject } = useMetaInfo();
+  const apiKey = getApiKey(activeProject);
+
+  return useMutation<Response, Error, string>({
+    mutationFn: (app_name) => deleteAppConfig(app_name, apiKey),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+    },
+  });
+};

--- a/frontend/src/hooks/use-app-config.tsx
+++ b/frontend/src/hooks/use-app-config.tsx
@@ -1,4 +1,3 @@
-// hooks/use-app-configs.tsx
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -13,12 +12,17 @@ import { useMetaInfo } from "@/components/context/metainfo";
 import { getApiKey } from "@/lib/api/util";
 import { AppConfig } from "@/lib/types/appconfig";
 
+export const appConfigKeys = {
+  all: ["appconfigs"] as const,
+  detail: (appName: string) => ["appconfigs", appName] as const,
+};
+
 export const useAppConfigs = () => {
   const { activeProject } = useMetaInfo();
   const apiKey = getApiKey(activeProject);
 
   return useQuery<AppConfig[], Error>({
-    queryKey: ["appconfigs"],
+    queryKey: appConfigKeys.all,
     queryFn: () => getAllAppConfigs(apiKey),
     enabled: !!apiKey,
 
@@ -42,7 +46,7 @@ export const useAppConfig = (appName: string) => {
   const apiKey = getApiKey(activeProject);
 
   return useQuery<AppConfig | null, Error>({
-    queryKey: ["appconfig", appName],
+    queryKey: appConfigKeys.detail(appName),
     queryFn: () => getAppConfig(appName, apiKey),
     enabled: !!apiKey && !!appName,
   });
@@ -73,7 +77,7 @@ export const useCreateAppConfig = () => {
         params.security_scheme_overrides,
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
     },
   });
 };
@@ -92,10 +96,10 @@ export const useUpdateAppConfig = () => {
     mutationFn: (params) =>
       updateAppConfig(params.app_name, params.enabled, apiKey),
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
       // The current page may only use the update of a single data item when updating
       queryClient.invalidateQueries({
-        queryKey: ["appconfig", variables.app_name],
+        queryKey: appConfigKeys.detail(variables.app_name),
       });
     },
   });
@@ -109,7 +113,7 @@ export const useDeleteAppConfig = () => {
   return useMutation<Response, Error, string>({
     mutationFn: (app_name) => deleteAppConfig(app_name, apiKey),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["appconfigs"] });
+      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
     },
   });
 };


### PR DESCRIPTION
…gs page

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

- Unify queryKey naming for useAppConfigs / useAppConfig to ['appconfigs'] and ['appconfig', name]
- Invalidate both list and item caches after update/delete mutations to prevent stale data in detail views
- Improve loading UX by using placeholderData or optionally keepPreviousData
- Standardize hook file naming to use-app-configs.tsx

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
