### PR TITLE
refactor: migrate project pages to TanStack Query (use-app-config hook)

### DIFF
--- a/frontend/src/app/linked-accounts/page.tsx
+++ b/frontend/src/app/linked-accounts/page.tsx
@@ -12,7 +12,6 @@ import {
   deleteLinkedAccount,
   updateLinkedAccount,
 } from "@/lib/api/linkedaccount";
-import { getAllAppConfigs } from "@/lib/api/appconfig";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,7 +26,6 @@ import {
 import { toast } from "sonner";
 import { Separator } from "@/components/ui/separator";
 import { LinkedAccountDetails } from "@/components/linkedaccount/linked-account-details";
-import { AppConfig } from "@/lib/types/appconfig";
 import { AddAccountForm } from "@/components/appconfig/add-account";
 import { App } from "@/lib/types/app";
 import { EnhancedSwitch } from "@/components/ui-extensions/enhanced-switch/enhanced-switch";
@@ -39,13 +37,15 @@ import { EnhancedDataTable } from "@/components/ui-extensions/enhanced-data-tabl
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
 const columnHelper = createColumnHelper<TableData>();
 import { useApps } from "@/hooks/use-app";
+import { useAppConfigs } from "@/hooks/use-app-config";
 
 type TableData = LinkedAccount & { logo: string };
 
 export default function LinkedAccountsPage() {
   const { activeProject } = useMetaInfo();
   const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[]>([]);
-  const [appConfigs, setAppConfigs] = useState<AppConfig[]>([]);
+  const { data: appConfigs = [], isPending: isConfigsPending } =
+    useAppConfigs();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const { data: apps, isPending, isError } = useApps();
   const [appsMap, setAppsMap] = useState<Record<string, App>>({});
@@ -88,20 +88,6 @@ export default function LinkedAccountsPage() {
       logo: appsMap[acc.app_name]?.logo ?? "",
     }));
   }, [linkedAccounts, appsMap]);
-
-  const loadAppConfigs = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const apiKey = getApiKey(activeProject);
-      const configs = await getAllAppConfigs(apiKey);
-      setAppConfigs(configs);
-    } catch (error) {
-      console.error("Failed to load app configurations:", error);
-      toast.error("Failed to load app configurations");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [activeProject]);
 
   const refreshLinkedAccounts = useCallback(
     async (silent: boolean = false) => {
@@ -147,12 +133,12 @@ export default function LinkedAccountsPage() {
   useEffect(() => {
     const loadData = async () => {
       setIsLoading(true);
-      await Promise.all([refreshLinkedAccounts(true), loadAppConfigs()]);
+      await refreshLinkedAccounts(true);
       setIsLoading(false);
     };
 
     loadData();
-  }, [activeProject, loadAppConfigs, refreshLinkedAccounts]);
+  }, [activeProject, refreshLinkedAccounts]);
 
   useEffect(() => {
     if (linkedAccounts.length > 0) {
@@ -350,6 +336,8 @@ export default function LinkedAccountsPage() {
     ] as ColumnDef<TableData>[];
   }, [toggleAccountStatus, refreshLinkedAccounts, activeProject]);
 
+  const isPageLoading = isLoading || isPending || isConfigsPending;
+
   return (
     <div>
       <div className="m-4 flex items-center justify-between">
@@ -360,7 +348,7 @@ export default function LinkedAccountsPage() {
           </p>
         </div>
         <div>
-          {!isLoading && !isPending && !isError && appConfigs.length > 0 && (
+          {!isPageLoading && !isError && appConfigs.length > 0 && (
             <AddAccountForm
               appInfos={appConfigs.map((config) => ({
                 name: config.app_name,
@@ -379,7 +367,7 @@ export default function LinkedAccountsPage() {
       <div className="m-4">
         <Tabs defaultValue={"linked"} className="w-full">
           <TabsContent value="linked">
-            {isLoading ? (
+            {isPageLoading ? (
               <div className="flex items-center justify-center p-8">
                 <div className="flex flex-col items-center space-y-4">
                   <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>

--- a/frontend/src/app/project-setting/page.tsx
+++ b/frontend/src/app/project-setting/page.tsx
@@ -15,38 +15,18 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useCallback, useEffect, useState } from "react";
-import { getApiKey } from "@/lib/api/util";
+import { useCallback } from "react";
 import { useAgentsTableColumns } from "@/components/project/useAgentsTableColumns";
 import { EnhancedDataTable } from "@/components/ui-extensions/enhanced-data-table/data-table";
 import { Agent } from "@/lib/types/project";
 import { toast } from "sonner";
 import { useMetaInfo } from "@/components/context/metainfo";
-import { AppConfig } from "@/lib/types/appconfig";
-import { getAllAppConfigs } from "@/lib/api/appconfig";
+import { useAppConfigs } from "@/hooks/use-app-config";
 
 export default function ProjectSettingPage() {
   const { accessToken, activeProject, reloadActiveProject } = useMetaInfo();
-  const [appConfigs, setAppConfigs] = useState<AppConfig[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const loadAppConfigs = useCallback(async () => {
-    const apiKey = getApiKey(activeProject);
-    setLoading(true);
-
-    try {
-      const configs = await getAllAppConfigs(apiKey);
-      setAppConfigs(configs);
-    } catch (error) {
-      console.error("Error fetching apps:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, [activeProject]);
-
-  useEffect(() => {
-    loadAppConfigs();
-  }, [activeProject, loadAppConfigs]);
+  const { data: appConfigs = [], isPending: isConfigsPending } =
+    useAppConfigs();
 
   const handleDeleteAgent = useCallback(
     async (agentId: string) => {
@@ -184,7 +164,6 @@ export default function ProjectSettingPage() {
                   (appConfig) => appConfig.app_name,
                 )}
                 appConfigs={appConfigs}
-                onRequestRefreshAppConfigs={loadAppConfigs}
                 onSubmit={async (values) => {
                   try {
                     await createAgent(
@@ -202,7 +181,7 @@ export default function ProjectSettingPage() {
                   }
                 }}
               >
-                <Button variant="outline" disabled={loading}>
+                <Button variant="outline" disabled={isConfigsPending}>
                   <MdAdd />
                   Create Agent
                   <Tooltip>

--- a/frontend/src/components/project/agent-form.tsx
+++ b/frontend/src/components/project/agent-form.tsx
@@ -61,7 +61,6 @@ interface AgentFormProps {
   title: string;
   validAppNames: string[];
   appConfigs?: AppConfig[];
-  onRequestRefreshAppConfigs: () => void;
 }
 
 export function AgentForm({
@@ -71,7 +70,6 @@ export function AgentForm({
   title,
   validAppNames,
   appConfigs = [],
-  onRequestRefreshAppConfigs,
 }: AgentFormProps) {
   const [open, setOpen] = useState(false);
   const [selectedApps, setSelectedApps] = useState<RowSelectionState>({});
@@ -139,11 +137,6 @@ export function AgentForm({
       console.error("Error submitting form:", error);
     }
   };
-  useEffect(() => {
-    if (open && onRequestRefreshAppConfigs) {
-      onRequestRefreshAppConfigs();
-    }
-  }, [open, onRequestRefreshAppConfigs]);
 
   // Reset form values when dialog opens
   useEffect(() => {

--- a/frontend/src/components/project/agent-instruction-filter-form.tsx
+++ b/frontend/src/components/project/agent-instruction-filter-form.tsx
@@ -18,13 +18,12 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
-import { getAllAppConfigs } from "@/lib/api/appconfig";
 import { updateAgent } from "@/lib/api/agent";
-import { AppConfig } from "@/lib/types/appconfig";
-import { getApiKey } from "@/lib/api/util";
 import { toast } from "sonner";
 import { useMetaInfo } from "@/components/context/metainfo";
 import { useApps } from "@/hooks/use-app";
+import { useAppConfigs } from "@/hooks/use-app-config";
+
 interface AgentInstructionFilterFormProps {
   children: React.ReactNode;
   projectId: string;
@@ -42,38 +41,19 @@ export function AgentInstructionFilterForm({
   allowedApps = [],
   onSaveSuccess,
 }: AgentInstructionFilterFormProps) {
-  const { activeProject, accessToken } = useMetaInfo();
+  const { accessToken } = useMetaInfo();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [appConfigs, setAppConfigs] = useState<AppConfig[]>([]);
+  const { data: appConfigs = [], isPending: isConfigsPending } =
+    useAppConfigs();
   const { data: apps, isPending, isError } = useApps();
   const [instructions, setInstructions] =
     useState<Record<string, string>>(initialInstructions);
 
-  // Fetch App configurations and App data
   useEffect(() => {
     if (!open) return;
-
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        const apiKey = getApiKey(activeProject);
-
-        // Get App configurations
-        const configs = await getAllAppConfigs(apiKey);
-        setAppConfigs(configs);
-
-        setLoading(false);
-      } catch (error) {
-        console.error("Failed to fetch data:", error);
-        toast.error("Failed to load app data");
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [open, activeProject]);
-
+    setLoading(isPending || isConfigsPending);
+  }, [open, isPending, isConfigsPending]);
   // Initialize instruction data when dialog opens
   useEffect(() => {
     if (open && initialInstructions) {

--- a/frontend/src/hooks/use-app-config.tsx
+++ b/frontend/src/hooks/use-app-config.tsx
@@ -16,9 +16,9 @@ import { toast } from "sonner";
 // TODO: think about what happens when the active project changes, and how to invalidate
 // the cache. May need to add project id to the query key.
 export const appConfigKeys = {
-  all: ["appconfigs"] as const,
-  detail: (appName: string | null | undefined) =>
-    ["appconfigs", appName ?? ""] as const,
+  all: (projectId: string) => ["appconfigs", projectId] as const,
+  detail: (projectId: string, appName: string | null | undefined) =>
+    ["appconfigs", projectId, appName ?? ""] as const,
 };
 
 export const useAppConfigs = () => {
@@ -26,7 +26,9 @@ export const useAppConfigs = () => {
   const apiKey = getApiKey(activeProject);
 
   return useQuery<AppConfig[], Error>({
-    queryKey: appConfigKeys.all,
+    // Use projectId in the query key to clearly isolate project-specific data without relying on API key changes.
+    // In order to maintain the same functionality as the original page, pay attention to the project switching situation
+    queryKey: appConfigKeys.all(activeProject.id),
     queryFn: () => getAllAppConfigs(apiKey),
   });
 };
@@ -36,7 +38,7 @@ export const useAppConfig = (appName?: string | null) => {
   const apiKey = getApiKey(activeProject);
 
   return useQuery<AppConfig | null, Error>({
-    queryKey: appConfigKeys.detail(appName),
+    queryKey: appConfigKeys.detail(activeProject.id, appName),
     queryFn: () =>
       appName ? getAppConfig(appName, apiKey) : Promise.resolve(null),
     enabled: !!appName,
@@ -68,11 +70,13 @@ export const useCreateAppConfig = () => {
         params.security_scheme_overrides,
       ),
     onSuccess: (newConfig) => {
-      queryClient.setQueryData<AppConfig[]>(appConfigKeys.all, (old = []) => [
-        ...old,
-        newConfig,
-      ]);
-      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
+      queryClient.setQueryData<AppConfig[]>(
+        appConfigKeys.all(activeProject.id),
+        (old = []) => [...old, newConfig],
+      );
+      queryClient.invalidateQueries({
+        queryKey: appConfigKeys.all(activeProject.id),
+      });
     },
     onError: (error) => {
       console.error("Create AppConfig failed:", error);
@@ -95,10 +99,12 @@ export const useUpdateAppConfig = () => {
     mutationFn: (params) =>
       updateAppConfig(params.app_name, params.enabled, apiKey),
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: appConfigKeys.all(activeProject.id),
+      });
       // The current page may only use the update of a single data item when updating
       queryClient.invalidateQueries({
-        queryKey: appConfigKeys.detail(variables.app_name),
+        queryKey: appConfigKeys.detail(activeProject.id, variables.app_name),
       });
     },
     onError: (error) => {
@@ -116,9 +122,11 @@ export const useDeleteAppConfig = () => {
   return useMutation<Response, Error, string>({
     mutationFn: (app_name) => deleteAppConfig(app_name, apiKey),
     onSuccess: (_, app_name) => {
-      queryClient.invalidateQueries({ queryKey: appConfigKeys.all });
       queryClient.invalidateQueries({
-        queryKey: appConfigKeys.detail(app_name),
+        queryKey: appConfigKeys.all(activeProject.id),
+      });
+      queryClient.invalidateQueries({
+        queryKey: appConfigKeys.detail(activeProject.id, app_name),
       });
     },
     onError: (error) => {


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

* **Project-scope replacement**

  * Added `appConfigKeys` with `projectId`-aware queryKeys to guarantee cache isolation.
  * Centralised all AppConfig data access in `hooks/use-app-config.ts` (`useAppConfigs`, `useAppConfig`, mutations).
  * Updated `MetaInfoProvider` comments & TODOs to reflect query-based reload strategy.

* **Page refactor**

  * `Page`, agent dialogs, and app-edit dialogs now pull data via `useAppConfigs` instead of `getAllAppConfigs`.
  * Removed local `loadAppConfigs` `useEffect`; loading state now derives from `isPending | isFetching`.

* **Test updates**

  * Replaced direct mocks of `getAllAppConfigs` with mocks of `useAppConfigs`.
  * Expanded `useMetaInfo` mock to include mandatory `user: UserClass` stub so hooks can de-structure correctly.
  * Added assertions for `useAppConfigs` invocation and for UI state based on mock `data`.

* **Misc**

  * Updated comments explaining why add `projectId` is used in `queryKey`.
  * Clean-up: removed redundant local loading flags, added `onSuccess` cache updates to mutations.

*No production UI changes*


### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
