### PR TITLE
fix: resolve form reset logic for custom OAuth2 switch

### DIFF
--- a/frontend/src/components/apps/configure-app/configure-app-step.tsx
+++ b/frontend/src/components/apps/configure-app/configure-app-step.tsx
@@ -100,8 +100,13 @@ export function ConfigureAppStep({
         return;
       }
     }
-
-    onNext(values);
+    const payload: ConfigureAppFormValues = {
+      ...values,
+      ...(values.security_scheme === "oauth2" && useACIDevOAuth2
+        ? { client_id: "", client_secret: "" }
+        : {}),
+    };
+    onNext(payload);
   };
 
   return (
@@ -148,13 +153,7 @@ export function ConfigureAppStep({
             <div className="flex items-center gap-2">
               <Switch
                 checked={useACIDevOAuth2}
-                onCheckedChange={(checked) => {
-                  setUseACIDevOAuth2(checked);
-                  form.setValue("client_id", "");
-                  form.setValue("client_secret", "");
-                  setIsRedirectConfirmed(false);
-                  setIsScopeConfirmed(false);
-                }}
+                onCheckedChange={setUseACIDevOAuth2}
               />
               <Label className="text-sm font-medium">
                 Use ACI.dev&apos;s OAuth2 App

--- a/frontend/src/components/apps/configure-app/configure-app-step.tsx
+++ b/frontend/src/components/apps/configure-app/configure-app-step.tsx
@@ -148,7 +148,13 @@ export function ConfigureAppStep({
             <div className="flex items-center gap-2">
               <Switch
                 checked={useACIDevOAuth2}
-                onCheckedChange={setUseACIDevOAuth2}
+                onCheckedChange={(checked) => {
+                  setUseACIDevOAuth2(checked);
+                  form.setValue("client_id", "");
+                  form.setValue("client_secret", "");
+                  setIsRedirectConfirmed(false);
+                  setIsScopeConfirmed(false);
+                }}
               />
               <Label className="text-sm font-medium">
                 Use ACI.dev&apos;s OAuth2 App


### PR DESCRIPTION
### 🏷️ Ticket
close #378 

### 📝 Description

- Adjust handleSubmit logic to prevent unnecessary form value mutation
- Construct payload based on OAuth2 switch state without modifying internal form state
- Ensure cleaner separation of form state and submission payload for consistent data flow
### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Switching between OAuth2 app options now properly resets related form fields and confirmation states to prevent outdated information from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->