### PR TITLE
Fix oauth2 comment

### DIFF
--- a/backend/aci/server/app_connectors/gmail.py
+++ b/backend/aci/server/app_connectors/gmail.py
@@ -41,7 +41,7 @@ class Gmail(AppConnectorBase):
         # e.g., if creds.expired and creds.refresh_token:
         #     creds.refresh(Request())
         # but this doesn't sit well with our existing credential fetch and update mechanism
-        # (which was built for generic oauht2/api_key rest apis)
+        # (which was built for generic oauth2/api_key REST APIs)
         pass
 
     # TODO: support HTML type for body


### PR DESCRIPTION
## Summary
- fix a typo in the Gmail app connector comment

## Testing
- `pre-commit run --files backend/aci/server/app_connectors/gmail.py` *(fails: command not found)*
- `cd backend && uv run ruff format .` *(fails: No route to host)*
