### PR TITLE
feat: Integration Google Meet

### DIFF
--- a/backend/apps/google_meet/app.json
+++ b/backend/apps/google_meet/app.json
@@ -1,0 +1,27 @@
+{
+  "name": "GOOGLE_MEET",
+  "display_name": "Google Meet",
+  "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/google_meet.svg",
+  "provider": "Google",
+  "version": "1.0.0",
+  "description": "The Google Meet API allows developers to access and manage Google Meet resources programmatically. It provides information about meetings, participants, and recordings through RESTful HTTP calls including listing conference records, participants, and meeting spaces.",
+  "security_schemes": {
+    "oauth2": {
+      "location": "header",
+      "name": "Authorization",
+      "prefix": "Bearer",
+      "client_id": "{{ AIPOLABS_GOOGLE_APP_CLIENT_ID }}",
+      "client_secret": "{{ AIPOLABS_GOOGLE_APP_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/meetings.space.readonly https://www.googleapis.com/auth/meetings.space.created",
+      "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
+    }
+  },
+  "default_security_credentials_by_scheme": {},
+  "categories": [
+    "Video Conferencing"
+  ],
+  "visibility": "public",
+  "active": true
+}

--- a/backend/apps/google_meet/functions.json
+++ b/backend/apps/google_meet/functions.json
@@ -1,0 +1,410 @@
+[
+    {
+        "name": "GOOGLE_MEET__CONFERENCE_RECORDS_LIST",
+        "description": "Lists the conference records. By default, ordered by start time and in descending order.",
+        "tags": ["meetings"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/conferenceRecords",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters for the request",
+                    "properties": {
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Maximum number of conference records to return. The service might return fewer than this value. If unspecified, at most 25 conference records are returned. The maximum value is 100.",
+                            "default": 25
+                        },
+                        "pageToken": {
+                            "type": "string",
+                            "description": "Page token returned from previous List Call."
+                        },
+                        "filter": {
+                            "type": "string",
+                            "description": "User specified filtering condition. For example: 'space.name = \"spaces/NAME\"', 'space.meeting_code = \"abc-mnop-xyz\"', 'start_time>=\"2024-01-01T00:00:00.000Z\" AND start_time<=\"2024-01-02T00:00:00.000Z\"', 'end_time IS NULL'"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["pageSize", "pageToken", "filter"],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": ["query"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__CONFERENCE_RECORDS_GET",
+        "description": "Gets a conference record by conference ID.",
+        "tags": ["meetings"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{name}",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The resource name of the conference record, format: conferenceRecords/{conference_record}",
+                            "pattern": "^conferenceRecords/[^/]+$"
+                        }
+                    },
+                    "required": ["name"],
+                    "visible": ["name"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__PARTICIPANTS_LIST",
+        "description": "Lists the participants in a conference record.",
+        "tags": ["meetings", "participants"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{parent}/participants",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "parent": {
+                            "type": "string",
+                            "description": "Conference record ID. Format: conferenceRecords/{conference_record}",
+                            "pattern": "^conferenceRecords/[^/]+$"
+                        }
+                    },
+                    "required": ["parent"],
+                    "visible": ["parent"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Maximum number of participants to return per page. Default 100, maximum 250.",
+                            "default": 100
+                        },
+                        "pageToken": {
+                            "type": "string",
+                            "description": "Page token for pagination"
+                        },
+                        "filter": {
+                            "type": "string",
+                            "description": "Filter condition. Example: latest_end_time IS NULL returns active participants"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["pageSize", "pageToken", "filter"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path", "query"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__PARTICIPANTS_GET",
+        "description": "Gets a participant by participant ID.",
+        "tags": ["meetings", "participants"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{name}",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Participant resource name. Format: conferenceRecords/{conference_record}/participants/{participant}",
+                            "pattern": "^conferenceRecords/[^/]+/participants/[^/]+$"
+                        }
+                    },
+                    "required": ["name"],
+                    "visible": ["name"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__PARTICIPANT_SESSIONS_LIST",
+        "description": "Lists the participant sessions of a participant in a conference record.",
+        "tags": ["meetings", "participants", "sessions"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{parent}/participantSessions",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "parent": {
+                            "type": "string",
+                            "description": "Participant resource name. Format: conferenceRecords/{conference_record}/participants/{participant}",
+                            "pattern": "^conferenceRecords/[^/]+/participants/[^/]+$"
+                        }
+                    },
+                    "required": ["parent"],
+                    "visible": ["parent"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Maximum number of sessions to return per page",
+                            "default": 100
+                        },
+                        "pageToken": {
+                            "type": "string",
+                            "description": "Page token for pagination"
+                        },
+                        "filter": {
+                            "type": "string",
+                            "description": "Filter condition. Example: end_time IS NULL returns active sessions"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["pageSize", "pageToken", "filter"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path", "query"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__SPACES_GET",
+        "description": "Gets details about a meeting space.",
+        "tags": ["meetings", "spaces"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{name}",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Resource name of the space. Format: spaces/{space}",
+                            "pattern": "^spaces/[^/]+$"
+                        }
+                    },
+                    "required": ["name"],
+                    "visible": ["name"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__SPACES_CREATE",
+        "description": "Creates a space.",
+        "tags": ["meetings", "spaces"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/v2/spaces",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Request body parameters",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "description": "Configuration pertaining to the meeting space",
+                            "properties": {
+                                "moderation": {
+                                    "type": "string",
+                                    "description": "The pre-configured moderation mode for the Meeting",
+                                    "enum": ["MODERATION_UNSPECIFIED", "OFF", "ON"]
+                                },
+                                "SmartNotesConfig": {
+                                    "type": "object",
+                                    "description": "Configuration related to smart notes in a meeting space",
+                                    "properties": {
+                                        "autoSmartNotesGeneration": {
+                                            "type": "string",
+                                            "description": "Defines whether to automatically generate a summary and recap",
+                                            "enum": ["AUTO_GENERATION_TYPE_UNSPECIFIED", "ON", "OFF"]
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": ["autoSmartNotesGeneration"],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [],
+                            "visible": ["moderation", "SmartNotesConfig"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [],
+                    "visible": ["config"],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": ["body"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__RECORDINGS_LIST",
+        "description": "Lists recordings from a conference record.",
+        "tags": ["meetings", "recordings"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{parent}/recordings",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "parent": {
+                            "type": "string",
+                            "description": "Conference record ID. Format: conferenceRecords/{conference_record}",
+                            "pattern": "^conferenceRecords/[^/]+$"
+                        }
+                    },
+                    "required": ["parent"],
+                    "visible": ["parent"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Maximum number of recordings to return per page",
+                            "default": 25
+                        },
+                        "pageToken": {
+                            "type": "string",
+                            "description": "Page token for pagination"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["pageSize", "pageToken"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path", "query"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GOOGLE_MEET__RECORDINGS_GET",
+        "description": "Gets details of a specific recording including Google Drive links.",
+        "tags": ["meetings", "recordings"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v2/{name}",
+            "server_url": "https://meet.googleapis.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Recording resource name. Format: conferenceRecords/{conference_record}/recordings/{recording}",
+                            "pattern": "^conferenceRecords/[^/]+/recordings/[^/]+$"
+                        }
+                    },
+                    "required": ["name"],
+                    "visible": ["name"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    }
+]


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/Google-Meet-1f88378d6a4780a89e60d02d0502c4ba

### 📝 Description

Implemented Google Meet API v2 integration with 9 key functions to enable comprehensive meeting management capabilities:

1. **Conference Records Management**
   - `GOOGLE_MEET__CONFERENCE_RECORDS_LIST`: List all conference records with filtering options
   - `GOOGLE_MEET__CONFERENCE_RECORDS_GET`: Retrieve details of a specific conference

2. **Participant Management**
   - `GOOGLE_MEET__PARTICIPANTS_LIST`: List all participants in a conference
   - `GOOGLE_MEET__PARTICIPANTS_GET`: Get details of a specific participant
   - `GOOGLE_MEET__PARTICIPANT_SESSIONS_LIST`: Track participant join/leave sessions

3. **Meeting Space Management**
   - `GOOGLE_MEET__SPACES_GET`: Retrieve meeting space details
   - `GOOGLE_MEET__SPACES_CREATE`: Create new meeting spaces with configurable settings

4. **Recording Management**
   - `GOOGLE_MEET__RECORDINGS_LIST`: List all recordings from a conference
   - `GOOGLE_MEET__RECORDINGS_GET`: Get details of a specific recording including Google Drive links

This implementation provides a complete interface to the Google Meet API, enabling applications to manage meetings, participants, spaces, and recordings programmatically.

#### Fuzzy Test Prompt

```bash
# List Conference Records
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__CONFERENCE_RECORDS_LIST \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "List all conference records from the last month. Set page size to 50 and filter by meetings that ended after May 19, 2024"

# Get Conference Record
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__CONFERENCE_RECORDS_GET \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Retrieve detailed information about the conference with ID 'conferenceRecords/<conference_id>'."

# List Participants
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__PARTICIPANTS_LIST \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "List all participants who joined the conference 'conferenceRecords/<conference_id>'."

# Get Participant
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__PARTICIPANTS_GET \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Get detailed information about participant 'conferenceRecords/<conference_id>/participants/<participant_id>' from conference 'conferenceRecords/<conference_id>'."

# List Participant Sessions
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__PARTICIPANT_SESSIONS_LIST \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Show all join/leave sessions for participant 'conferenceRecords/<conference_id>/participants/<participant_id>' in conference 'conferenceRecords/<conference_id>'. Return maximum 50 sessions."

# Get Meeting Space
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__SPACES_GET \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Get detailed information about the meeting space with ID 'spaces/<space_id>', including meeting code and URL."

# Create Meeting Space
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__SPACES_CREATE \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Create a new meeting space with moderation turned ON."

# List Recordings
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__RECORDINGS_LIST \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "List all recordings from conference 'conferenceRecords/<conference_id>'. Return up to 25 recordings per page."

# Get Recording
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_MEET__RECORDINGS_GET \
  --linked-account-owner-id <account_id> \
  --aci-api-key <api_key> \
  --prompt "Get details about recording '<recording_id>' from conference 'conferenceRecords/<conference_id>', including Google Drive links to download the recording."
```



### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

Test result screenshots are paste in: https://www.notion.so/Google-Meet-1f88378d6a4780a89e60d02d0502c4ba

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced Google Meet integration, enabling access to meetings, participants, sessions, spaces, and recordings.
	- Added support for listing, retrieving, and creating meeting spaces with advanced options.
	- Enabled OAuth2 authentication for secure access to Google Meet data.
	- Provided endpoints for accessing Google Meet recordings, including links to Google Drive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->