### PR TITLE
refactor: Skip security scheme override if useACIDevOAuth2 is true

### DIFF
--- a/frontend/src/components/apps/configure-app/configure-app-step.tsx
+++ b/frontend/src/components/apps/configure-app/configure-app-step.tsx
@@ -42,7 +42,7 @@ const oauth2RedirectUrl = `${process.env.NEXT_PUBLIC_API_URL}/v1/linked-accounts
 interface ConfigureAppStepProps {
   form: ReturnType<typeof useForm<ConfigureAppFormValues>>;
   supported_security_schemes: Record<string, { scope?: string }>;
-  onNext: (values: ConfigureAppFormValues) => void;
+  onNext: (values: ConfigureAppFormValues, useACIDevOAuth2: boolean) => void;
   name: string;
   isLoading: boolean;
 }
@@ -100,13 +100,7 @@ export function ConfigureAppStep({
         return;
       }
     }
-    const payload: ConfigureAppFormValues = {
-      ...values,
-      ...(values.security_scheme === "oauth2" && useACIDevOAuth2
-        ? { client_id: "", client_secret: "" }
-        : {}),
-    };
-    onNext(payload);
+    onNext(values, useACIDevOAuth2);
   };
 
   return (

--- a/frontend/src/components/apps/configure-app/index.tsx
+++ b/frontend/src/components/apps/configure-app/index.tsx
@@ -139,7 +139,10 @@ export function ConfigureApp({
   }, [open, activeProject]);
 
   // step 1 submit
-  const handleConfigureAppSubmit = async (values: ConfigureAppFormValues) => {
+  const handleConfigureAppSubmit = async (
+    values: ConfigureAppFormValues,
+    useACIDevOAuth2: boolean,
+  ) => {
     setSelectedSecurityScheme(values.security_scheme);
     setSubmitLoading(true);
 
@@ -148,8 +151,9 @@ export function ConfigureApp({
 
       if (
         values.security_scheme === "oauth2" &&
-        values.client_id &&
-        values.client_secret
+        !useACIDevOAuth2 &&
+        !!values.client_id &&
+        !!values.client_secret
       ) {
         security_scheme_overrides = {
           oauth2: {


### PR DESCRIPTION
### 📝 Description

* Use `useACIDevOAuth2` to decide if the security scheme should be empty or not

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved app configuration flow with enhanced handling of OAuth2 options, allowing users to specify when to use an alternative OAuth2 method during app setup.

- **Bug Fixes**
  - Fixed an issue where OAuth2 client credentials could be incorrectly set when using the alternative OAuth2 method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->