### PR TITLE
refactor: show correct toast when quota is exceeded

### DIFF
--- a/backend/aci/common/exceptions.py
+++ b/backend/aci/common/exceptions.py
@@ -437,9 +437,12 @@ class OAuth2Error(ACIException):
 class MaxUniqueLinkedAccountOwnerIdsReached(ACIException):
     """Raised when an organization has reached its maximum allowed linked accounts for an app."""
 
-    def __init__(self, message: str | None = None):
+    def __init__(self, plan: str | None = None, message: str | None = None):
+        title = "Max unique linked account owner ids reached"
+        if plan:
+            title = f"{title} for the {plan} plan"
         super().__init__(
-            title="Max unique linked account owner ids reached",
+            title=title,
             message=message,
             error_code=status.HTTP_403_FORBIDDEN,
         )

--- a/backend/aci/server/quota_manager.py
+++ b/backend/aci/server/quota_manager.py
@@ -125,4 +125,4 @@ def enforce_linked_accounts_creation_quota(
                 "plan": plan.name,
             },
         )
-        raise MaxUniqueLinkedAccountOwnerIdsReached()
+        raise MaxUniqueLinkedAccountOwnerIdsReached(plan.name)

--- a/frontend/src/components/appconfig/add-account.tsx
+++ b/frontend/src/components/appconfig/add-account.tsx
@@ -152,11 +152,9 @@ export function AddAccountForm({ appInfos }: AddAccountProps) {
         })
         .catch((err) => {
           console.error("Failed to copy:", err);
-          toast.error("Failed to copy OAuth2 Link URL to clipboard");
         });
     } catch (error) {
       console.error(error);
-      toast.error("Failed to copy OAuth2 Link URL to clipboard");
     }
   };
 
@@ -178,7 +176,6 @@ export function AddAccountForm({ appInfos }: AddAccountProps) {
       window.location.href = oauth2LinkURL;
     } catch (error) {
       console.error("Error linking OAuth2 account:", error);
-      toast.error("Failed to link account");
     }
   };
 
@@ -203,7 +200,6 @@ export function AddAccountForm({ appInfos }: AddAccountProps) {
       setOpen(false);
     } catch (error) {
       console.error("Error linking API account:", error);
-      toast.error("Failed to link account");
     }
   };
 
@@ -226,7 +222,6 @@ export function AddAccountForm({ appInfos }: AddAccountProps) {
       setOpen(false);
     } catch (error) {
       console.error("Error linking no auth account:", error);
-      toast.error("Failed to link account");
     }
   };
 

--- a/frontend/src/hooks/use-linked-account.tsx
+++ b/frontend/src/hooks/use-linked-account.tsx
@@ -13,6 +13,7 @@ import {
 import { useMetaInfo } from "@/components/context/metainfo";
 import { getApiKey } from "@/lib/api/util";
 import { LinkedAccount } from "@/lib/types/linkedaccount";
+import { toast } from "sonner";
 
 const linkedAccountKeys = {
   all: (projectId: string) => [projectId, "linkedaccounts"] as const,
@@ -66,6 +67,9 @@ export const useCreateAPILinkedAccount = () => {
       queryClient.invalidateQueries({
         queryKey: linkedAccountKeys.all(activeProject.id),
       }),
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 };
 
@@ -90,6 +94,9 @@ export const useCreateNoAuthLinkedAccount = () => {
       queryClient.invalidateQueries({
         queryKey: linkedAccountKeys.all(activeProject.id),
       }),
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 };
 type GetOauth2LinkURLParams = {
@@ -110,6 +117,9 @@ export const useGetOauth2LinkURL = () => {
         apiKey,
         params.afterOAuth2LinkRedirectURL,
       ),
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 };
 

--- a/frontend/src/lib/api/linkedaccount.ts
+++ b/frontend/src/lib/api/linkedaccount.ts
@@ -75,9 +75,16 @@ export async function createAPILinkedAccount(
   );
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to create linked account: ${response.status} ${response.statusText}`,
-    );
+    let errorMsg = `Failed to create linked account: ${response.status} ${response.statusText}`;
+    try {
+      const errorData = await response.json();
+      if (errorData && errorData.error) {
+        errorMsg = errorData.error;
+      }
+    } catch (e) {
+      console.error("Error parsing error response:", e);
+    }
+    throw new Error(errorMsg);
   }
 
   const linkedAccount = await response.json();
@@ -105,9 +112,16 @@ export async function createNoAuthLinkedAccount(
   );
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to create no auth linked account: ${response.status} ${response.statusText}`,
-    );
+    let errorMsg = `Failed to create no auth linked account: ${response.status} ${response.statusText}`;
+    try {
+      const errorData = await response.json();
+      if (errorData && errorData.error) {
+        errorMsg = errorData.error;
+      }
+    } catch (e) {
+      console.error("Error parsing error response:", e);
+    }
+    throw new Error(errorMsg);
   }
 
   const linkedAccount = await response.json();
@@ -141,9 +155,16 @@ export async function getOauth2LinkURL(
   );
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to get OAuth2 link URL: ${response.status} ${response.statusText}`,
-    );
+    let errorMsg = `Failed to get OAuth2 link URL: ${response.status} ${response.statusText}`;
+    try {
+      const errorData = await response.json();
+      if (errorData && errorData.error) {
+        errorMsg = errorData.error;
+      }
+    } catch (e) {
+      console.error("Error parsing error response:", e);
+    }
+    throw new Error(errorMsg);
   }
 
   const data = await response.json();


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

Adds improved error‐response parsing to the three linked‐account functions (createLinkedAccount, createNoAuthLinkedAccount, getOauth2LinkURL) so that when the backend returns a structured error (e.g. quota exceeded), the exact message is surfaced to the user instead of a generic HTTP-status error.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f8706364-72b9-4d4c-a97d-b03e03dc7949)
![image](https://github.com/user-attachments/assets/1fcfc321-77dc-4262-8883-4a22d3d0eeff)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
