### PR TITLE
Chore/filter health logs

### DIFF
--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -59,7 +59,7 @@ services:
     ports:
       - "8000:8000"
     # this overrides the default CMD specified in the Dockerfile, use this for local development
-    command: uvicorn aci.server.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn aci.server.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --reload --no-access-log
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
### 🏷️ Ticket

N/A

### 📝 Description

Filter health logs so that they don't bloat the stdout of `docker compose` and also enable `no-access-logs` since they are already provided by the `InterceptorMiddleware`

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Suppressed logging of health check requests and responses in the local environment to reduce log noise.
	- Disabled access log output for the backend server in the local Docker Compose setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->