### PR TITLE
fix: Add --no-dev to server Dockerfile

### DIFF
--- a/backend/Dockerfile.server
+++ b/backend/Dockerfile.server
@@ -4,7 +4,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /workdir
 
 COPY ./pyproject.toml ./uv.lock /workdir/
-RUN uv sync --no-install-project
+RUN uv sync --no-dev --no-install-project
 
 ENV PATH="/workdir/.venv/bin:$PATH"
 ENV PYTHONPATH=/workdir:${PYTHONPATH}


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

By default, `uv sync` will install all dependencies including dev ones, we need `--no-dev` for the server Dockerfile we use in production.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency installation process to exclude development dependencies during server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->