### PR TITLE
bug: Fix the bug in `linked_account_owner_id_exists_in_org` function

### DIFF
--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_quota.py
@@ -148,3 +148,75 @@ def test_linked_accounts_quota_for_multiple_projects_in_an_org(
         headers={"x-api-key": dummy_api_key_2},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_linked_accounts_quota_for_the_same_owner_id(
+    test_client: TestClient,
+    dummy_api_key_1: str,
+    dummy_app_configuration_no_auth_mock_app_connector_project_1: AppConfigurationPublic,
+    dummy_app_configuration_api_key_github_project_1: AppConfigurationPublic,
+    dummy_app_configuration_api_key_aci_test_project_1: AppConfigurationPublic,
+    free_plan: Plan,
+) -> None:
+    # Given: User has already linked the same owner id with two different apps
+    same_owner_id = "test_same_owner_id"
+
+    # Create linked account with no-auth app (mock app connector)
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+        json=LinkedAccountNoAuthCreate(
+            app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+            linked_account_owner_id=same_owner_id,
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Create linked account with same owner ID but different app (github)
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_github_project_1.app_name,
+            linked_account_owner_id=same_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Then: User can create more unique owner IDs up to the quota limit (mock app connector)
+    for i in range(1, free_plan.features["linked_accounts"]):
+        unique_owner_id = f"unique_owner_{i}"
+        response = test_client.post(
+            f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+            json=LinkedAccountNoAuthCreate(
+                app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+                linked_account_owner_id=unique_owner_id,
+            ).model_dump(mode="json", exclude_none=True),
+            headers={"x-api-key": dummy_api_key_1},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    # Then: User can still create another linked account with the same owner ID in a different app (aci test)
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/api-key",
+        json=LinkedAccountAPIKeyCreate(
+            app_name=dummy_app_configuration_api_key_aci_test_project_1.app_name,
+            linked_account_owner_id=same_owner_id,
+            api_key="aci_api_key",
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Then: User cannot create a new linked account with a new unique owner ID (quota exceeded)
+    new_unique_owner_id = f"unique_owner_{free_plan.features['linked_accounts']}"
+    response = test_client.post(
+        f"{config.ROUTER_PREFIX_LINKED_ACCOUNTS}/no-auth",
+        json=LinkedAccountNoAuthCreate(
+            app_name=dummy_app_configuration_no_auth_mock_app_connector_project_1.app_name,
+            linked_account_owner_id=new_unique_owner_id,
+        ).model_dump(mode="json", exclude_none=True),
+        headers={"x-api-key": dummy_api_key_1},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
### 📝 Description

The bug was in the following function:

```python
def linked_account_owner_id_exists_in_org(
    db_session: Session, org_id: UUID, linked_account_owner_id: str
) -> bool:
    statement = select(LinkedAccount).filter(
        LinkedAccount.linked_account_owner_id == linked_account_owner_id,
        LinkedAccount.project_id.in_(select(Project.id).filter(Project.org_id == org_id)),
    )
    return db_session.execute(statement).scalar_one_or_none() is not None
```

Here I was using `scalar_one_or_none`, which throws the following exception when there are multiple rows matching:
```python
Traceback (most recent call last):
  File "/workdir/.venv/lib/python3.12/site-packages/logfire/_internal/integrations/fastapi.py", line 262, in run_endpoint_function
    return await original_run_endpoint_function(dependant=dependant, values=values, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/aci/server/routes/linked_accounts.py", line 383, in link_oauth2_account
    quota_manager.enforce_linked_accounts_creation_quota(
  File "/workdir/aci/server/quota_manager.py", line 91, in enforce_linked_accounts_creation_quota
    if crud.linked_accounts.linked_account_owner_id_exists_in_org(
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/aci/common/db/crud/linked_accounts.py", line 197, in linked_account_owner_id_exists_in_org
    return db_session.execute(statement).scalar_one_or_none() is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/.venv/lib/python3.12/site-packages/sqlalchemy/engine/result.py", line 1492, in scalar_one_or_none
    return self._only_one_row(
           ^^^^^^^^^^^^^^^^^^^
  File "/workdir/.venv/lib/python3.12/site-packages/sqlalchemy/engine/result.py", line 813, in _only_one_row
    raise exc.MultipleResultsFound(
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
```

When a user has the same linked account owner id configured in two or more apps, the SQLAlchemy statement will throw the `multiple rows were found error`, but all we need to check is just if one or more row exists. I changed the function implementation to use `exists()` function from SQLAlchemy, which will just return a bool or None.

```python
def linked_account_owner_id_exists_in_org(
    db_session: Session, org_id: UUID, linked_account_owner_id: str
) -> bool:
    statement = select(
        exists().where(
            LinkedAccount.linked_account_owner_id == linked_account_owner_id,
            LinkedAccount.project_id.in_(select(Project.id).filter(Project.org_id == org_id)),
        )
    )
    return db_session.execute(statement).scalar() or False
```

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
