### PR TITLE
fix: add scroll container to app-edit-form to support long app list

### DIFF
--- a/frontend/src/components/project/app-edit-form.tsx
+++ b/frontend/src/components/project/app-edit-form.tsx
@@ -153,17 +153,19 @@ export function AppEditForm({
                 <p>No app configurations available</p>
               </div>
             ) : (
-              <EnhancedDataTable
-                columns={columns}
-                data={appConfigs}
-                defaultSorting={[{ id: "app_name", desc: false }]}
-                searchBarProps={{ placeholder: "Search apps..." }}
-                rowSelectionProps={{
-                  rowSelection: selectedApps,
-                  onRowSelectionChange: setSelectedApps,
-                  getRowId: (row) => row.app_name,
-                }}
-              />
+              <div className="max-h-[45vh] overflow-y-auto">
+                <EnhancedDataTable
+                  columns={columns}
+                  data={appConfigs}
+                  defaultSorting={[{ id: "app_name", desc: false }]}
+                  searchBarProps={{ placeholder: "Search apps..." }}
+                  rowSelectionProps={{
+                    rowSelection: selectedApps,
+                    onRowSelectionChange: setSelectedApps,
+                    getRowId: (row) => row.app_name,
+                  }}
+                />
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
### 🏷️ Ticket

#411 

### 📝 Description

Fixes the issue where app-edit-form.tsx could not scroll when the enabled apps list grows too long.
### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/dcdb9f70-0872-41c3-8cce-300e0e9fb12c)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
