### PR TITLE
bug: Fix agent initialization logic in useAgentStore

### DIFF
--- a/frontend/src/lib/store/agent.ts
+++ b/frontend/src/lib/store/agent.ts
@@ -157,12 +157,25 @@ export const useAgentStore = create<AgentState>()(
       },
       initializeFromProject: (project: Project) => {
         if (project?.agents && project.agents.length > 0) {
-          // set default agent
+          // After the selected agent's loaded from session storage,
+          // we need to check if the selected agent is still in the project.
+          // If not, we need to set the default agent to the first agent in the project.
+          const currentSelectedAgent = get().selectedAgent;
+          let selectedAgent = currentSelectedAgent;
+
+          if (
+            !project.agents.find((agent) => agent.id === currentSelectedAgent)
+          ) {
+            selectedAgent = project.agents[0].id;
+          }
+
           set((state) => ({
             ...state,
             agents: project.agents,
-            selectedAgent: project.agents[0].id,
-            allowedApps: project.agents[0].allowed_apps || [],
+            selectedAgent: selectedAgent,
+            allowedApps:
+              project.agents.find((agent) => agent.id === selectedAgent)
+                ?.allowed_apps || [],
           }));
         }
       },


### PR DESCRIPTION
### 📝 Description

> when he logged into that, the browser had already cached the Default agent ID from his previous login, so when he entered the agent playground the entire webpage just crashed (see screenshot).

![image](https://github.com/user-attachments/assets/f0aca6ee-eaa9-424b-bc68-79bef70c3829)

Updated the `initializeFromProject` function to ensure that the selected agent is valid. If the currently selected agent is not found in the project, it defaults to the first agent in the project. This change improves the handling of agent selection and allowed apps assignment.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent selection behavior to preserve your previously selected agent when switching projects, as long as it remains available. This prevents unnecessary resets of your chosen agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->