### PR TITLE
Fix the selected agent not exist bug in getApiKey as well

### DIFF
--- a/frontend/src/lib/store/agent.ts
+++ b/frontend/src/lib/store/agent.ts
@@ -63,7 +63,25 @@ export const useAgentStore = create<AgentState>()(
       setAgents: (agents: Agent[]) =>
         set((state) => ({ ...state, agents: agents })),
       getApiKey: (activeProject: Project) => {
-        const apiKey = getApiKey(activeProject, get().selectedAgent);
+        let selectedAgent = get().selectedAgent;
+        const agentExists = activeProject.agents?.some(
+          (agent) => agent.id === selectedAgent,
+        );
+
+        if (
+          !agentExists &&
+          activeProject.agents &&
+          activeProject.agents.length > 0
+        ) {
+          selectedAgent = activeProject.agents[0].id;
+          set((state) => ({
+            ...state,
+            selectedAgent,
+            allowedApps: activeProject.agents[0].allowed_apps || [],
+          }));
+        }
+
+        const apiKey = getApiKey(activeProject, selectedAgent);
         return apiKey;
       },
       fetchLinkedAccounts: async (apiKey: string) => {


### PR DESCRIPTION
### 📝 Description

Updated the `getApiKey` function to ensure that if the selected agent is not found in the active project, it defaults to the first available agent. This change improves the handling of agent selection and ensures that allowed apps are correctly assigned based on the selected agent.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
