### PR TITLE
bug: Fix the stale linked accounts bug

### DIFF
--- a/frontend/src/hooks/use-app-config.tsx
+++ b/frontend/src/hooks/use-app-config.tsx
@@ -12,6 +12,7 @@ import { useMetaInfo } from "@/components/context/metainfo";
 import { getApiKey } from "@/lib/api/util";
 import { AppConfig } from "@/lib/types/appconfig";
 import { toast } from "sonner";
+import { linkedAccountKeys } from "./use-linked-account";
 
 // TODO: think about what happens when the active project changes, and how to invalidate
 // the cache. May need to add project id to the query key.
@@ -128,6 +129,9 @@ export const useDeleteAppConfig = () => {
       });
       queryClient.invalidateQueries({
         queryKey: appConfigKeys.detail(activeProject.id, app_name),
+      });
+      queryClient.invalidateQueries({
+        queryKey: linkedAccountKeys.all(activeProject.id),
       });
     },
     onError: (error) => {

--- a/frontend/src/hooks/use-linked-account.tsx
+++ b/frontend/src/hooks/use-linked-account.tsx
@@ -15,7 +15,7 @@ import { getApiKey } from "@/lib/api/util";
 import { LinkedAccount } from "@/lib/types/linkedaccount";
 import { toast } from "sonner";
 
-const linkedAccountKeys = {
+export const linkedAccountKeys = {
   all: (projectId: string) => [projectId, "linkedaccounts"] as const,
 };
 


### PR DESCRIPTION
### 📝 Description

When we delete an app configuration, the linked accounts under it are also deleted, but the frontend cache is not updated.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that linked account data is properly refreshed when an app configuration is deleted, improving data consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->