### PR TITLE
Added test container

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -68,7 +68,7 @@ jobs:
         id: run_tests
         working-directory: backend
         run: |
-          docker compose -f compose.yml -f compose.ci.yml run runner
+          docker compose -f compose.test.yml -f compose.ci.yml run runner
 
       - name: Get service names
         id: service_names

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -68,7 +68,7 @@ jobs:
         id: run_tests
         working-directory: backend
         run: |
-          docker compose -f compose.test.yml -f compose.ci.yml run runner
+          docker compose -f compose.yml -f compose.ci.yml run runner
 
       - name: Get service names
         id: service_names

--- a/backend/README.md
+++ b/backend/README.md
@@ -182,19 +182,15 @@ For VS Code users, configure Ruff formatter:
 
 ### Running Tests
 
-Ensure the `db` service is running and the database is empty (in case you have seeded
-the db in `step 6`) before running tests.
-
-> [!NOTE]
-> More specifically, if you have run the `seed_db.sh` script already, you need to bring
-> down docker compose and bring it up again without running the `seed_db.sh` script this
-> time.
-
-Then you can run the test in the `runner` container:
+You can run the tests using:
 
 ```bash
-docker compose exec runner pytest
+docker compose -f compose.test.yml -p test run runner
 ```
+
+> [!NOTE]
+> The `-p` flag ensures the test containers are launched on a separate stack called `test` so that they don't
+> conflicts with the dev containers which are by default launched on `backend_default`
 
 ## Database Management
 

--- a/backend/compose.test.yml
+++ b/backend/compose.test.yml
@@ -52,6 +52,7 @@ services:
     volumes:
       - ./aci/server:/workdir/aci/server
       - ./aci/common:/workdir/aci/common
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     command: uvicorn aci.server.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --no-access-log
     depends_on:
       db:
@@ -76,6 +77,7 @@ services:
       - ./scripts:/workdir/scripts
       - ./evals:/workdir/evals
       - ./alembic.ini:/workdir/alembic.ini
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     command: >
       /bin/sh -c "alembic upgrade head && pytest $PYTEST_ARGS"
     depends_on:

--- a/backend/compose.test.yml
+++ b/backend/compose.test.yml
@@ -1,0 +1,92 @@
+services:
+  db:
+    image: pgvector/pgvector:pg17
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d local_db"]
+      interval: 1s
+      retries: 5
+      start_period: 1s
+      timeout: 10s
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: local_db
+    restart: no
+    networks:
+      - test_network
+
+  aws:
+    image: localstack/localstack
+    environment:
+      - DEBUG=1
+      - DATA_DIR=/var/lib/localstack/data
+      - SERVICES=kms
+    volumes:
+      - ./scripts/create-kms-encryption-key.sh:/etc/localstack/init/ready.d/create-kms-encryption-key.sh
+    networks:
+      - test_network
+
+  propelauth_mock:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    working_dir: /workdir
+    volumes:
+      - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
+    command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800
+    networks:
+      - test_network
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    healthcheck:
+      test: ["CMD-SHELL", "curl localhost:8000/v1/health"]
+      interval: 10s
+      retries: 5
+      start_period: 3s
+      timeout: 10s
+    env_file:
+      - .env.local
+    volumes:
+      - ./aci/server:/workdir/aci/server
+      - ./aci/common:/workdir/aci/common
+    command: uvicorn aci.server.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --no-access-log
+    depends_on:
+      db:
+        condition: service_healthy
+      aws:
+        condition: service_healthy
+    restart: no
+    networks:
+      - test_network
+
+  runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    env_file:
+      - .env.local
+    environment:
+      - PYTEST_ARGS=${PYTEST_ARGS:-}
+    volumes:
+      - ./aci:/workdir/aci
+      - ./apps:/workdir/apps
+      - ./scripts:/workdir/scripts
+      - ./evals:/workdir/evals
+      - ./alembic.ini:/workdir/alembic.ini
+    command: >
+      /bin/sh -c "alembic upgrade head && pytest $PYTEST_ARGS"
+    depends_on:
+      db:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+    networks:
+      - test_network
+
+networks:
+  test_network:
+    name: aci_test_network
+    driver: bridge


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=2018378d6a4780dcbfadfa51b275a6b8&pm=s)

### 📝 Description

Isolate test container from dev container. Before they were merged together and when we wanted to run tests we needed to `docker compose down -v`, run the tests and then reseed the db.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated Docker Compose configuration for testing, providing an isolated multi-service test environment.
- **Documentation**
	- Updated and simplified backend testing instructions to reflect the new test setup and commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->