### PR TITLE
fix: Make it clear limits are set at org level

### DIFF
--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -243,6 +243,12 @@ export default function PricingPage() {
             </Card>
           ))}
         </div>
+        <div className="mx-auto mt-8 max-w-2xl text-center">
+          <p className="text-sm text-muted-foreground">
+            Rate limits are set at the organization level, so every project in
+            the same organization draws from the same allowance.
+          </p>
+        </div>
         <FaqSection />
       </div>
     </div>


### PR DESCRIPTION
### 🏷️ Ticket

[Make it clear that Pricing is applied at the Org level](https://www.notion.so/Make-it-clear-that-Pricing-is-applied-at-the-Org-level-1f88378d6a4780249603ecce9afe3a9f?pvs=4)

### 📝 Description

Add a note to clarify the limits

### 📸 Screenshots

<img width="1536" alt="Screenshot 2025-05-28 at 11 15 40 PM" src="https://github.com/user-attachments/assets/177f79d9-6340-422d-bc41-1ab1fdf9c194" />

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an informational message below the pricing tier cards on the pricing page to clarify that rate limits apply at the organization level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->