### PR TITLE
add optional redirect_url oauth2 override for complete whilelabeling

### DIFF
--- a/backend/aci/common/schemas/app_configurations.py
+++ b/backend/aci/common/schemas/app_configurations.py
@@ -66,7 +66,8 @@ class AppConfigurationCreate(BaseModel):
 
 
 class AppConfigurationUpdate(BaseModel):
-    # TODO: we currently don't support changing security_scheme and security_scheme_overrides (e.g., client_id, client_secret)
+    # TODO: we currently don't support changing security_scheme and security_scheme_overrides (e.g., client_id, client_secret, redirect_url).
+    # it might be useful to support updating custom redirect_url.
     enabled: bool | None = None
     all_functions_enabled: bool | None = None
     enabled_functions: list[str] | None = None

--- a/backend/aci/common/schemas/security_scheme.py
+++ b/backend/aci/common/schemas/security_scheme.py
@@ -1,6 +1,6 @@
 from typing import Literal, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from aci.common.enums import HttpLocation
 
@@ -42,11 +42,13 @@ class OAuth2Scheme(BaseModel):
     client_id: str = Field(
         ...,
         min_length=1,
+        max_length=2048,
         description="The client ID of the OAuth2 client (provided by ACI) used for the app",
     )
     client_secret: str = Field(
         ...,
         min_length=1,
+        max_length=2048,
         description="The client secret of the OAuth2 client (provided by ACI) used for the app",
     )
     scope: str = Field(
@@ -71,6 +73,12 @@ class OAuth2Scheme(BaseModel):
         description="The authentication method for the OAuth2 token endpoint, e.g., 'client_secret_post' "
         "for some providers that require client_id/client_secret to be sent in the body of the token request, like Hubspot",
     )
+    # NOTE: For now this field should not be provided when creating a new OAuth2 App (because the current server redirect URL should be used,
+    # which is constructed dynamically).
+    # It only makes sense for user to provide it in OAuth2SchemeOverride if they want whitelabeling.
+    redirect_url: str | None = Field(
+        default=None, min_length=1, max_length=2048, description="Redirect URL for OAuth2 callback."
+    )
 
 
 # NOTE: need to show these fields for custom oauth2 app feature.
@@ -91,14 +99,39 @@ class OAuth2SchemeOverride(BaseModel):
     client_id: str = Field(
         ...,
         min_length=1,
+        max_length=2048,
         description="The client ID of the OAuth2 client used for the app",
     )
     client_secret: str = Field(
         ...,
         min_length=1,
+        max_length=2048,
         description="The client secret of the OAuth2 client used for the app",
     )
-    # TODO: will support "scope" and "redirect_uri" in the future, both will be optional
+    # NOTE: for some OAuth2 app such as google apps, it will still show "ACI.dev" on the authorization page even if the user provides their own OAuth2 app.
+    # It's because the domains shown there is determined by the redirect URL.
+    # If user needs complete whitelabeling, they need to provide a custom redirect URL (and set it as redirect URL in their OAuth2 app)
+    # and forward the OAuth2 callback response to ACI.dev's callback endpoint.
+    # e.g, https://my-app.com/v1/linked-accounts/oauth2/callback (set as redirect URL in OAuth2 app) --forward--> https://api.aci.dev/v1/linked-accounts/oauth2/callback
+    redirect_url: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=2048,
+        description="Custom redirect URL for OAuth2 callback for complete whitelabeling. "
+        "If not provided, ACI.dev's server redirect URL will be used. "
+        "When user uses a custom redirect URL, their backend should forward the OAuth2 callback response to ACI.dev's callback endpoint.",
+    )
+
+    @field_validator("redirect_url", check_fields=False)
+    def validate_redirect_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # sanity check: must be http or https
+        if not (v.startswith("http") or v.startswith("https")):
+            raise ValueError("Redirect URL must start with http or https")
+        return v
+
+    # TODO: might need to support "scope" in the future
 
 
 class NoAuthScheme(BaseModel, extra="forbid"):

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -400,7 +400,7 @@ async def link_oauth2_account(
     )
 
     path = request.url_for(LINKED_ACCOUNTS_OAUTH2_CALLBACK_ROUTE_NAME).path
-    redirect_uri = f"{config.REDIRECT_URI_BASE}{path}"
+    redirect_uri = oauth2_scheme.redirect_url or f"{config.REDIRECT_URI_BASE}{path}"
 
     # create and encode the state payload.
     # NOTE: the state payload is jwt encoded (signed), but it's not encrypted, anyone can decode it

--- a/backend/aci/server/tests/routes/app_configurations/test_app_configurations_add.py
+++ b/backend/aci/server/tests/routes/app_configurations/test_app_configurations_add.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -41,10 +42,17 @@ def test_create_app_configuration(
     assert str(response.json()["error"]).startswith("App configuration already exists")
 
 
+# use paramterize to test two cases:
+# 1. no redirect_url
+# 2. with redirect_url
+@pytest.mark.parametrize(
+    "redirect_url", [None, "https://api.user-app.com/v1/linked-accounts/oauth2/callback"]
+)
 def test_create_app_configuration_with_security_scheme_override(
     test_client: TestClient,
     dummy_api_key_1: str,
     dummy_apps: list[App],
+    redirect_url: str | None,
 ) -> None:
     dummy_app = dummy_apps[0]
     body = AppConfigurationCreate.model_validate(
@@ -52,7 +60,11 @@ def test_create_app_configuration_with_security_scheme_override(
             "app_name": dummy_app.name,
             "security_scheme": SecurityScheme.OAUTH2,
             "security_scheme_overrides": {
-                "oauth2": {"client_id": "123456", "client_secret": "abcdef"}
+                "oauth2": {
+                    "client_id": "123456",
+                    "client_secret": "abcdef",
+                    "redirect_url": redirect_url,
+                }
             },
         }
     )
@@ -68,6 +80,10 @@ def test_create_app_configuration_with_security_scheme_override(
     assert app_configuration.security_scheme_overrides.oauth2.client_secret == "******", (
         "client_secret should be redacted"
     )
+    if redirect_url:
+        assert app_configuration.security_scheme_overrides.oauth2.redirect_url == redirect_url
+    else:
+        assert app_configuration.security_scheme_overrides.oauth2.redirect_url is None
 
 
 def test_create_app_configuration_security_scheme_not_supported(


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/OAUTH2-whitelabel-redirect-URL-1f88378d6a4780fc8082eb5a86ed6a63

### 📝 Description

Add backend support to allow custom redirect url (part of the custom oauth2 app) for oauth2 app configuration:
- without this feature, for some oauth2 providers like google, it still shows ACI.dev's domain on the authorization page.
- The custom redirect url is needed to generate oauth2 authorization url.
- frontend change is in a separate pr.
- Added testcase overage.
- No database migration should be needed.

