### PR TITLE
fix: Implement cascading deletion of secrets for linked accounts

### DIFF
--- a/backend/aci/common/db/sql_models.py
+++ b/backend/aci/common/db/sql_models.py
@@ -440,6 +440,11 @@ class LinkedAccount(Base):
         ),
     )
 
+    # deleting linked account will delete all associated secrets
+    secrets: Mapped[list[Secret]] = relationship(
+        "Secret", lazy="select", cascade="all, delete-orphan", init=False
+    )
+
 
 class Secret(Base):
     __tablename__ = "secrets"


### PR DESCRIPTION
### 🏷️ Ticket

[Fix secrets table deletion cascade bug](https://www.notion.so/Fix-secrets-table-deletion-cascade-bug-2018378d6a47802fb0a8d075f3eb79b9?source=copy_link)

### 📝 Description

- Added a relationship in the LinkedAccount model to ensure that all associated secrets are deleted when a linked account is removed.
- Introduced a new test to verify that secrets are automatically deleted upon the deletion of their parent linked account, ensuring data integrity and proper cascading behavior.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that all secrets associated with a linked account are automatically deleted when the linked account is removed.

- **Tests**
	- Added a test to verify that secrets are deleted when their parent linked account is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->