### PR TITLE
add remove chat button on agent playground

### DIFF
--- a/backend/aci/common/encryption.py
+++ b/backend/aci/common/encryption.py
@@ -3,7 +3,7 @@ import hmac
 from typing import cast
 
 import aws_encryption_sdk  # type: ignore
-import boto3
+import boto3  # type: ignore
 from aws_cryptographic_material_providers.mpl import (  # type: ignore
     AwsCryptographicMaterialProviders,
 )

--- a/backend/aci/common/encryption.py
+++ b/backend/aci/common/encryption.py
@@ -3,7 +3,7 @@ import hmac
 from typing import cast
 
 import aws_encryption_sdk  # type: ignore
-import boto3  # type: ignore
+import boto3
 from aws_cryptographic_material_providers.mpl import (  # type: ignore
     AwsCryptographicMaterialProviders,
 )

--- a/frontend/src/app/playground/overview.tsx
+++ b/frontend/src/app/playground/overview.tsx
@@ -1,3 +1,4 @@
+import { BetaAlert } from "@/components/playground/beta-alert";
 import * as motion from "motion/react-client";
 import Image from "next/image";
 
@@ -5,13 +6,16 @@ export const Overview = () => {
   return (
     <motion.div
       key="overview"
-      className="max-w-3xl mx-auto md:mt-20"
+      className="max-w-3xl mx-auto md:mt-12"
       initial={{ opacity: 0, scale: 0.98 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.98 }}
       transition={{ delay: 0.5 }}
     >
       <div className="rounded-xl p-6 flex flex-col leading-relaxed text-center max-w-xl">
+        <div className="flex flex-col gap-4 mb-24">
+          <BetaAlert />
+        </div>
         <p className="flex flex-row justify-center gap-4 items-center mb-36">
           <Image
             src="/aci-dev-full-logo.svg"

--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -7,8 +7,9 @@ import { SettingsSidebar } from "./playground-settings";
 import { ChatInput } from "./chat-input";
 import { Messages } from "./messages";
 import { useShallow } from "zustand/react/shallow";
-import { BetaAlert } from "@/components/playground/beta-alert";
 import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
 
 const chatHistoryLocalStorageKey = `playground-chat-history`;
 const Page = () => {
@@ -45,6 +46,7 @@ const Page = () => {
     }
     return [];
   };
+
   const {
     messages,
     input,
@@ -89,6 +91,11 @@ const Page = () => {
     addToolResult({ toolCallId, result });
   };
 
+  const handleClearMessages = () => {
+    sessionStorage.removeItem(chatHistoryLocalStorageKey);
+    setMessages([]);
+  };
+
   if (!activeProject) {
     console.warn("No active project");
     return <div>No project selected</div>;
@@ -98,7 +105,18 @@ const Page = () => {
     <div className="flex flex-grow h-[calc(100vh-6rem)]">
       {/* Left part - Chat area */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        <BetaAlert />
+        <div className="flex flex-col gap-4 mb-1 bg-transparent">
+          {messages.length > 0 && (
+            <Button
+              variant="outline"
+              onClick={handleClearMessages}
+              className="w-32 ml-3 mt-2 h-8 w-28"
+            >
+              <Trash2 className="h-4 w-4" />
+              Clear Chat
+            </Button>
+          )}
+        </div>
         <Messages
           messages={messages}
           status={status}
@@ -106,6 +124,7 @@ const Page = () => {
           apiKey={apiKey}
           addToolResult={handleAddToolResult}
         />
+
         <ChatInput
           input={input}
           setMessages={setMessages}


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/add-clear-button-on-agent-playground-2078378d6a47803ab65ee40e67eab9c6?source=copy_link

### 📝 Description

1. add clear chat button on agent playground
2. move alert to overview of agent playground

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/733950e7-0795-4f6c-ba6a-da0f67ff3024" />

<img width="868" alt="image" src="https://github.com/user-attachments/assets/2ff878ff-ac6f-4494-83a2-736b4d5d46bf" />

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Clear Chat" button in the chat area, allowing users to quickly clear their chat history when messages are present.

- **Style**
  - Updated the layout of the Overview section, including repositioning the BetaAlert and adjusting spacing for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->