### PR TITLE
Improve configure app button loading state

### DIFF
--- a/frontend/src/app/apps/[appName]/page.tsx
+++ b/frontend/src/app/apps/[appName]/page.tsx
@@ -18,12 +18,14 @@ import Image from "next/image";
 import { ConfigureApp } from "@/components/apps/configure-app";
 import { EnhancedDataTable } from "@/components/ui-extensions/enhanced-data-table/data-table";
 import { useAppConfig } from "@/hooks/use-app-config";
+import { Loader2 } from "lucide-react";
 
 const AppPage = () => {
   const { appName } = useParams<{ appName: string }>();
   const [functions, setFunctions] = useState<AppFunction[]>([]);
   const { app } = useApp(appName);
-  const { data: appConfig } = useAppConfig(appName);
+  const { data: appConfig, isPending: isAppConfigLoading } =
+    useAppConfig(appName);
 
   const columns = useAppFunctionsColumns();
 
@@ -68,9 +70,18 @@ const AppPage = () => {
             >
               <Button
                 className="bg-primary text-white hover:bg-primary/90"
-                disabled={appConfig !== null}
+                disabled={isAppConfigLoading || appConfig !== null}
               >
-                {appConfig ? "Configured" : "Configure App"}
+                {isAppConfigLoading ? (
+                  <div className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading...
+                  </div>
+                ) : appConfig ? (
+                  "Configured"
+                ) : (
+                  "Configure App"
+                )}
               </Button>
             </ConfigureApp>
           )}

--- a/frontend/src/app/apps/[appName]/page.tsx
+++ b/frontend/src/app/apps/[appName]/page.tsx
@@ -70,7 +70,7 @@ const AppPage = () => {
             >
               <Button
                 className="bg-primary text-white hover:bg-primary/90"
-                disabled={isAppConfigLoading || appConfig !== null}
+                disabled={isAppConfigLoading || !!appConfig}
               >
                 {isAppConfigLoading ? (
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- show a spinner for Configure App button until app config loads

## Testing
- `npm run format`
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_683f31e93248832eb40ab48799ea68c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a loading spinner and "Loading..." label to the "Configure App" button while app configuration data is loading.
- **Bug Fixes**
  - The "Configure App" button is now disabled during loading to prevent unintended interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->