### PR TITLE
feat: integrate project api with tanstack query

### DIFF
--- a/frontend/src/app/project-setting/page.tsx
+++ b/frontend/src/app/project-setting/page.tsx
@@ -13,7 +13,7 @@ import {
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { useMetaInfo } from "@/components/context/metainfo";
-import { updateProject } from "@/lib/api/project";
+import { useUpdateProject } from "@/hooks/use-project";
 import { Button } from "@/components/ui/button";
 import { DeleteProjectDialog } from "@/components/project/delete-project-dialog";
 
@@ -21,7 +21,8 @@ export default function ProjectSettingPage() {
   const { activeProject } = useMetaInfo();
   const [projectName, setProjectName] = useState(activeProject.name);
   const [isEditingName, setIsEditingName] = useState(false);
-  const { accessToken, reloadActiveProject } = useMetaInfo();
+  const { mutateAsync: updateProject, isPending: isProjectUpdating } =
+    useUpdateProject();
 
   // Update state when active project changes
   useEffect(() => {
@@ -42,8 +43,9 @@ export default function ProjectSettingPage() {
     }
 
     try {
-      await updateProject(accessToken, activeProject.id, projectName);
-      await reloadActiveProject();
+      await updateProject({
+        name: projectName,
+      });
       setIsEditingName(false);
       toast.success("Project name updated");
     } catch (error) {
@@ -74,7 +76,7 @@ export default function ProjectSettingPage() {
                 value={projectName}
                 onChange={(e) => setProjectName(e.target.value)}
                 className="w-96"
-                disabled={!isEditingName}
+                disabled={!isEditingName || isProjectUpdating}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     handleSaveProjectName();
@@ -91,6 +93,7 @@ export default function ProjectSettingPage() {
                 variant="ghost"
                 onClick={handleSaveProjectName}
                 className="h-8 w-8 p-0"
+                disabled={isProjectUpdating}
               >
                 <Check className="h-4 w-4" />
               </Button>
@@ -148,11 +151,7 @@ export default function ProjectSettingPage() {
                   permanently deletes the project and all related data.
                 </p>
               </div>
-              <DeleteProjectDialog
-                accessToken={accessToken}
-                projectId={activeProject.id}
-                projectName={activeProject.name}
-              />
+              <DeleteProjectDialog projectName={activeProject.name} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/layout/project-selector.tsx
+++ b/frontend/src/components/layout/project-selector.tsx
@@ -25,14 +25,8 @@ import { GoPlus } from "react-icons/go";
 import { CreateProjectDialog } from "@/components/project/create-project-dialog";
 
 export const ProjectSelector = () => {
-  const {
-    projects,
-    activeProject,
-    setActiveProject,
-    accessToken,
-    reloadActiveProject,
-    activeOrg,
-  } = useMetaInfo();
+  const { projects, activeProject, setActiveProject, reloadActiveProject } =
+    useMetaInfo();
   const [open, setOpen] = useState(false);
   const [openCreateDialog, setOpenCreateDialog] = useState(false);
 
@@ -106,8 +100,6 @@ export const ProjectSelector = () => {
       </Popover>
 
       <CreateProjectDialog
-        accessToken={accessToken}
-        orgId={activeOrg.orgId}
         onProjectCreated={reloadActiveProject}
         openDialog={openCreateDialog}
         setOpenDialog={setOpenCreateDialog}

--- a/frontend/src/components/project/delete-project-dialog.tsx
+++ b/frontend/src/components/project/delete-project-dialog.tsx
@@ -20,33 +20,26 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { deleteProject } from "@/lib/api/project";
+import { useDeleteProject } from "@/hooks/use-project";
 import { useMetaInfo } from "@/components/context/metainfo";
 import { useRouter } from "next/navigation";
 
 interface DeleteProjectDialogProps {
-  accessToken: string;
-  projectId: string;
   projectName: string;
 }
 
-export function DeleteProjectDialog({
-  accessToken,
-  projectId,
-  projectName,
-}: DeleteProjectDialogProps) {
-  console.log("projectName", projectName);
-  const [isDeleting, setIsDeleting] = useState(false);
+export function DeleteProjectDialog({ projectName }: DeleteProjectDialogProps) {
   const [confirmName, setConfirmName] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-  const { reloadActiveProject, projects } = useMetaInfo();
+  const { projects } = useMetaInfo();
   const router = useRouter();
+  const { mutateAsync: deleteProject, isPending: isProjectDeleting } =
+    useDeleteProject();
 
   const isLastProject = projects.length === 1;
 
   const resetForm = () => {
     setConfirmName("");
-    setIsDeleting(false);
   };
 
   const handleDeleteProject = async () => {
@@ -56,18 +49,12 @@ export function DeleteProjectDialog({
     }
 
     try {
-      setIsDeleting(true);
-      await deleteProject(accessToken, projectId);
-      await reloadActiveProject();
-      toast.success("Project deleted successfully");
+      await deleteProject();
       setIsOpen(false);
       resetForm();
       router.push("/apps");
     } catch (error) {
-      console.error("Failed to delete project:", error);
-      toast.error("Failed to delete project");
-    } finally {
-      setIsDeleting(false);
+      console.error("delete project failed:", error);
     }
   };
 
@@ -121,9 +108,9 @@ export function DeleteProjectDialog({
           <AlertDialogAction
             onClick={handleDeleteProject}
             className="bg-red-600 hover:bg-red-700"
-            disabled={isDeleting || confirmName !== projectName}
+            disabled={isProjectDeleting || confirmName !== projectName}
           >
-            {isDeleting ? "Deleting..." : "Delete Project"}
+            {isProjectDeleting ? "Deleting..." : "Delete Project"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/frontend/src/hooks/use-project.tsx
+++ b/frontend/src/hooks/use-project.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import {
+  getProjects,
+  createProject,
+  updateProject,
+  deleteProject,
+} from "@/lib/api/project";
+import { Project } from "@/lib/types/project";
+import { toast } from "sonner";
+import { useMetaInfo } from "@/components/context/metainfo";
+export const projectKeys = {
+  all: (orgId: string) => ["projects", orgId] as const,
+  detail: (orgId: string, projectId: string) =>
+    ["projects", orgId, projectId] as const,
+};
+
+export const useProjects = (orgId?: string, accessToken?: string) => {
+  return useQuery<Project[], Error>({
+    queryKey: orgId ? projectKeys.all(orgId) : ["projects"],
+    queryFn: async () => {
+      const fetchedProjects = await getProjects(accessToken!, orgId!);
+
+      return [...fetchedProjects].sort((a, b) => {
+        return (
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        );
+      });
+    },
+    enabled: !!orgId && !!accessToken,
+    retry: 2,
+    retryDelay: 1000,
+  });
+};
+
+export const useProject = (projectId?: string) => {
+  const { activeOrg, accessToken } = useMetaInfo();
+  const { data: projects } = useProjects(activeOrg.orgId, accessToken);
+
+  return {
+    project: projectId ? projects?.find((p) => p.id === projectId) : undefined,
+    projects,
+  };
+};
+
+type CreateProjectParams = {
+  name: string;
+};
+
+export const useCreateProject = () => {
+  const queryClient = useQueryClient();
+  const { activeOrg, accessToken } = useMetaInfo();
+  return useMutation<Project, Error, CreateProjectParams>({
+    mutationFn: (params) =>
+      createProject(accessToken, params.name, activeOrg.orgId),
+    onSuccess: (newProject) => {
+      queryClient.setQueryData<Project[]>(
+        projectKeys.all(activeOrg.orgId),
+        (old = []) => [...old, newProject],
+      );
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.all(activeOrg.orgId),
+      });
+      toast.success("project created successfully");
+    },
+    onError: (error) => {
+      console.error("create project failed:", error);
+      toast.error("create project failed");
+    },
+  });
+};
+
+type UpdateProjectParams = {
+  name: string;
+};
+
+export const useUpdateProject = () => {
+  const queryClient = useQueryClient();
+  const { activeProject, accessToken, activeOrg } = useMetaInfo();
+
+  return useMutation<Project, Error, UpdateProjectParams>({
+    mutationFn: (params) =>
+      updateProject(accessToken, activeProject.id, params.name),
+    onSuccess: (updatedProject) => {
+      queryClient.setQueryData<Project[]>(
+        projectKeys.all(activeOrg.orgId),
+        (old = []) =>
+          old.map((project) =>
+            project.id === activeProject.id ? updatedProject : project,
+          ),
+      );
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.all(activeOrg.orgId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.detail(activeOrg.orgId, activeProject.id),
+      });
+      toast.success("project updated successfully");
+    },
+    onError: (error) => {
+      console.error("update project failed:", error);
+      toast.error("update project failed");
+    },
+  });
+};
+
+export const useDeleteProject = () => {
+  const queryClient = useQueryClient();
+  const { activeProject, accessToken, activeOrg } = useMetaInfo();
+  return useMutation<void, Error>({
+    mutationFn: () => deleteProject(accessToken, activeProject.id),
+    onSuccess: () => {
+      queryClient.setQueryData<Project[]>(
+        projectKeys.all(activeOrg.orgId),
+        (old = []) => old.filter((project) => project.id !== activeProject.id),
+      );
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.all(activeOrg.orgId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.detail(activeOrg.orgId, activeProject.id),
+      });
+      toast.success("project deleted successfully");
+    },
+    onError: (error) => {
+      console.error("delete project failed:", error);
+      toast.error("delete project failed");
+    },
+  });
+};
+
+// provide a method to reload projects
+export const useReloadProjects = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (orgId: string) => {
+      if (orgId) {
+        await queryClient.invalidateQueries({
+          queryKey: projectKeys.all(orgId),
+        });
+      }
+    },
+    [queryClient],
+  );
+};

--- a/frontend/src/hooks/use-project.tsx
+++ b/frontend/src/hooks/use-project.tsx
@@ -66,8 +66,11 @@ export const useCreateProject = () => {
       toast.success("project created successfully");
     },
     onError: (error) => {
-      console.error("create project failed:", error);
-      toast.error("create project failed");
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("create project failed");
+      }
     },
   });
 };


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=2028378d6a4780ef8185e30338ab0755&pm=s)

### 📝 Description

Added use-project TanStack Query files to centralize project list and detail fetching logic.
Added useProjects, useProject, useCreateProject, useUpdateProject, useDeleteProject, and useReloadProjects hooks in hooks/use-project.ts.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced project management capabilities, including streamlined creation, updating, and deletion of projects using improved UI feedback and loading states.

- **Refactor**
  - Simplified project-related dialogs and settings screens for a more intuitive experience, with fewer required inputs and clearer feedback during operations.
  - Centralized project data handling, resulting in more consistent and responsive updates across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->