### PR TITLE
chore: Make sure we only send data to sentry on staging and production envs

### DIFF
--- a/backend/aci/server/sentry.py
+++ b/backend/aci/server/sentry.py
@@ -4,7 +4,9 @@ from aci.server import config
 
 
 def setup_sentry() -> None:
-    if config.ENVIRONMENT != "local":
+    if config.ENVIRONMENT != "local" and (
+        config.ENVIRONMENT == "staging" or config.ENVIRONMENT == "production"
+    ):
         sentry_sdk.init(
             environment=config.ENVIRONMENT,
             dsn="https://9cebb66f55b0782e37370b08be11f1f5@o4508859021459456.ingest.us.sentry.io/4508915251871744",


### PR DESCRIPTION
### 📝 Description

I want to use logfire for local development by setting my personal logfire org tokens and changing the `SERVER_ENVIRONMENT` to `localdev` so that my local server will send logs to logfire.

However, since the sentry env logic is also publish to sentry if `SERVER_ENVIRONMENT != "local"`. This PR makes the sentry check more strict, so that when I change `SERVER_ENVIRONMENT` to `localdev`, logfire will be enabled but sentry will not.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment detection to ensure Sentry is only initialized in "staging" or "production" environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->