### PR TITLE
feat: update comingsoon apps and filter out already launched ones

### DIFF
--- a/frontend/src/components/apps/app-grid.tsx
+++ b/frontend/src/components/apps/app-grid.tsx
@@ -8,10 +8,14 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { AppCard } from "./app-card";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { App } from "@/lib/types/app";
 import { AppCardComingSoon } from "./app-card-coming-soon";
 import comingsoon from "@/lib/comingsoon/comingsoon.json";
+
+function normalize(str: string): string {
+  return str.toLowerCase().replace(/[\s\-_]/g, "");
+}
 interface AppGridProps {
   apps: App[];
 }
@@ -37,7 +41,21 @@ export function AppGrid({ apps }: AppGridProps) {
     return matchesNameOrDescriptionOrCategory && matchesCategory;
   });
 
-  const comingSoonApps = comingsoon;
+  const liveAppKeys = useMemo(() => {
+    const keys = new Set<string>();
+    apps.forEach((app) => {
+      keys.add(normalize(app.name));
+      // Since the names are not uniform, use a filter to make unique
+      if (app.display_name && app.display_name !== app.name) {
+        keys.add(normalize(app.display_name));
+      }
+    });
+    return keys;
+  }, [apps]);
+
+  const comingSoonApps = useMemo(() => {
+    return comingsoon.filter((app) => !liveAppKeys.has(normalize(app.title)));
+  }, [liveAppKeys]);
 
   return (
     <div className="space-y-6">

--- a/frontend/src/lib/comingsoon/comingsoon.json
+++ b/frontend/src/lib/comingsoon/comingsoon.json
@@ -5,11 +5,6 @@
     "description": "Connect to Google Drive!"
   },
   {
-    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/apaleo.png",
-    "title": "Apaleo",
-    "description": "Apaleo is a cloud-based property management platform handling reservations, billing, and daily operations for hospitality businesses"
-  },
-  {
     "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/cal.png",
     "title": "Cal",
     "description": "Cal simplifies meeting coordination by providing shareable booking pages, calendar syncing, and availability management to streamline the scheduling process"
@@ -185,11 +180,6 @@
     "description": "Monday is a cloud-based work operating system where teams create\n    workflow apps in minutes to run their processes, projects, and\n    everyday work."
   },
   {
-    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/wrike.png",
-    "title": "Wrike",
-    "description": "Wrike is a project management and collaboration tool offering customizable workflows, Gantt charts, reporting, and resource management to boost team productivity"
-  },
-  {
     "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/d2lbrightspace.png",
     "title": "D2lbrightspace",
     "description": "D2L Brightspace provides APIs for building custom integrations and add-ons\n    for the D2L Brightspace platform."
@@ -203,11 +193,6 @@
     "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/microsoft_teams.jpg",
     "title": "Microsoft teams",
     "description": "Connect to Microsoft Teams to manage channels."
-  },
-  {
-    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/share_point.svg",
-    "title": "Share point",
-    "description": "SharePoint is a Microsoft platform for document management and intranets, enabling teams to collaborate, store, and organize content securely and effectively"
   },
   {
     "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/outlook.svg",


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=2038378d6a4780c693e6eea2614368f0&pm=s)

### 📝 Description

- Added normalize() function to unify app names (lowercase, remove spaces/hyphens/underscores).
- Built liveAppKeys using useMemo, based on both name and display_name.
- Filtered comingsoon.json entries whose titles match normalized live app names.
- Updated layout to only show truly "Coming Soon" apps not yet available.
- Remove 3 item in comingsoon.json
### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of the "Coming Soon" app list by ensuring apps already available are no longer shown as coming soon, even if their names have minor differences.
- **Chores**
  - Removed "Apaleo," "Wrike," and "Share point" from the list of upcoming integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->