### PR TITLE
chore: Set agent's allowed_apps to empty in the create-random-api-key command

### DIFF
--- a/backend/aci/cli/commands/create_random_api_key.py
+++ b/backend/aci/cli/commands/create_random_api_key.py
@@ -6,9 +6,7 @@ This will:
 - create a new dummy agent in the project
 """
 
-import json
 import uuid
-from pathlib import Path
 
 import click
 from rich.console import Console
@@ -55,18 +53,12 @@ def create_random_api_key_helper(visibility_access: Visibility, org_id: uuid.UUI
         visibility_access=visibility_access,
         skip_dry_run=skip_dry_run,
     )
-    # Load app names from app.json files
-    allowed_apps = []
-    for app_file in Path("./apps").glob("*/app.json"):
-        with open(app_file) as f:
-            app_data = json.load(f)
-            allowed_apps.append(app_data["name"])
 
     agent_id = create_agent.create_agent_helper(
         project_id=project_id,
         name=f"Test Agent {random_id}",
-        description=f"Test Agent {random_id}",
-        allowed_apps=allowed_apps,
+        description="This agent is created by the create-random-api-key CLI command",
+        allowed_apps=[],
         custom_instructions={},
         skip_dry_run=skip_dry_run,
     )


### PR DESCRIPTION
### 📝 Description

Set agent's allowed_apps to empty in the create-random-api-key command

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified agent creation by removing dynamic loading of allowed app names and using a fixed agent description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->