### PR TITLE
feat: Add CALENDLY__GET_CURRENT_USER function to API

### DIFF
--- a/backend/apps/calendly/functions.json
+++ b/backend/apps/calendly/functions.json
@@ -340,5 +340,42 @@
             "additionalProperties": false
         },
         "response": {}
+    },
+    {
+        "name": "CALENDLY__GET_CURRENT_USER",
+        "description": "Get basic information about your user account",
+        "tags": ["calendar", "details"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/users/me",
+            "server_url": "https://api.calendly.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "type": "object",
+                    "description": "HTTP request headers",
+                    "properties": {
+                        "accept": {
+                            "type": "string",
+                            "description": "Accept content type",
+                            "default": "application/json",
+                            "enum": ["application/json"]
+                        }
+                    },
+                    "required": ["accept"],
+                    "visible": ["accept"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["header"],
+            "visible": ["header"],
+            "additionalProperties": false
+        },
+        "response": {}
     }
 ]


### PR DESCRIPTION
### 📝 Description
Introduced a new API function to retrieve basic information about the current user account from Calendly. This function includes detailed specifications for request headers and response structure, enhancing the API's capabilities for user account management.

### ✅ Checklist
- [x] Updated the functions.json to include the new endpoint
- [x] Ensured compliance with API standards and documentation requirements

### 📝 Description

Added Get user URI function (calendly)

### Fuzzy Testing

<img width="511" alt="Screenshot 2025-06-12 at 13 10 40" src="https://github.com/user-attachments/assets/d6430c0c-50ee-4aaa-965f-55109f7a43da" />

### Result

<img width="814" alt="Screenshot 2025-06-12 at 13 10 58" src="https://github.com/user-attachments/assets/223cb157-4ef4-464b-8e37-47b63f9fc085" />


### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve the current user's information from Calendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->