### PR TITLE
Fix: Update health check services parameter type from array to string

### DIFF
--- a/backend/apps/supabase/functions.json
+++ b/backend/apps/supabase/functions.json
@@ -766,11 +766,8 @@
                     "description": "query parameters",
                     "properties": {
                         "services": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            },
-                            "description": "List of services to check health for (e.g., auth, db, storage, realtime, functions)"
+                            "type": "string",
+                            "description": "Comma-separated list of services to check health for (e.g., 'auth,db,pooler,realtime,rest,storage')"
                         },
                         "timeout_ms": {
                             "type": "integer",


### PR DESCRIPTION
### 📝 Description

Changed the `services` parameter type from an array of strings to a single string, allowing for a comma-separated list of services to check health for, because this parameter is in the query parameter and not body.

Perviously, I would get this error:

<img width="819" alt="Screenshot 2025-06-16 at 7 24 31 PM" src="https://github.com/user-attachments/assets/84c8c310-90e6-4b76-a3b1-d0cba9f1f4db" />

After the fix it now works:

<img width="635" alt="Screenshot 2025-06-16 at 7 25 24 PM" src="https://github.com/user-attachments/assets/25982b51-6583-4beb-bf87-b2bbd0c25e54" />


### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the "services" query parameter format for project health status checks. Now accepts a single comma-separated string (e.g., "auth,db,pooler,realtime,rest,storage") instead of an array.
- **Documentation**
  - Improved parameter description to clarify the new input format for service names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->