### PR TITLE
fix: Update vercel functions to include 'teamId' and 'slug' in visible properties

### DIFF
--- a/backend/apps/vercel/functions.json
+++ b/backend/apps/vercel/functions.json
@@ -179,7 +179,7 @@
                         }
                     },
                     "required": [],
-                    "visible": [],
+                    "visible": ["teamId", "slug"],
                     "additionalProperties": false
                 }
             },
@@ -319,7 +319,7 @@
                         }
                     },
                     "required": [],
-                    "visible": [],
+                    "visible": ["teamId", "slug"],
                     "additionalProperties": false
                 }
             },
@@ -377,7 +377,7 @@
                         }
                     },
                     "required": [],
-                    "visible": ["limit", "search", "repo", "repoId", "repoUrl"],
+                    "visible": ["limit", "search", "repo", "repoId", "repoUrl", "teamId", "slug"],
                     "additionalProperties": false
                 }
             },
@@ -428,7 +428,7 @@
                         }
                     },
                     "required": [],
-                    "visible": [],
+                    "visible": ["teamId", "slug"],
                     "additionalProperties": false
                 }
             },
@@ -547,7 +547,7 @@
                         }
                     },
                     "required": [],
-                    "visible": ["forceNew", "skipAutoDetectionConfirmation"],
+                    "visible": ["forceNew", "skipAutoDetectionConfirmation", "teamId", "slug"],
                     "additionalProperties": false
                 }
             },
@@ -598,7 +598,7 @@
                         }
                     },
                     "required": [],
-                    "visible": [],
+                    "visible": ["teamId", "slug"],
                     "additionalProperties": false
                 },
                 "body": {
@@ -696,7 +696,9 @@
                         "gitBranch",
                         "redirects",
                         "verified",
-                        "limit"
+                        "limit",
+                        "teamId",
+                        "slug"
                     ],
                     "additionalProperties": false
                 }
@@ -752,7 +754,7 @@
                         }
                     },
                     "required": [],
-                    "visible": [],
+                    "visible": ["teamId", "slug"],
                     "additionalProperties": false
                 }
             },


### PR DESCRIPTION
### 📝 Description

We need this to create Vercel projects that link to GitLab repos under a GitLab org.

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved API endpoints for Vercel projects and domains to accept "teamId" and "slug" as visible query parameters, enabling more flexible team-based requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->