### PR TITLE
fix: Make framework optional as it's optional on the official API

### DIFF
--- a/backend/apps/vercel/functions.json
+++ b/backend/apps/vercel/functions.json
@@ -155,7 +155,7 @@
                             }
                         }
                     },
-                    "required": ["name", "framework"],
+                    "required": ["name"],
                     "visible": [
                         "name",
                         "framework",


### PR DESCRIPTION
### 📝 Description

I made `framework` param required to make the VibeOps demo smooth. Reverting it now to get some flexibility back.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
