### PR TITLE
update backend workflow to support both same repo and fork repo run

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,7 @@ name: Backend Checks
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
   schedule:
     - cron: "0 9 * * *"
@@ -12,10 +12,15 @@ jobs:
   lint:
     name: Format & Lint
     runs-on: ubuntu-latest
+    # Only apply environment protection (requires approval) for fork PRs
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'CICD_FOR_FORKED_REPO' || null }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For pull_request_target: checkout PR head, otherwise use default (main for push/schedule)
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -49,12 +54,18 @@ jobs:
     name: Compose Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Only apply environment protection (requires approval) for fork PRs
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'CICD_FOR_FORKED_REPO' || null }}
     env:
       SERVER_OPENAI_API_KEY: ${{ secrets.SERVER_OPENAI_API_KEY }}
       CLI_OPENAI_API_KEY: ${{ secrets.CLI_OPENAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # For pull_request_target: checkout PR head, otherwise use default (main for push/schedule)
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1


### PR DESCRIPTION
### Problem
PR from forked repo won't be able to run CICD due to not having access to secrets.
  
### Solution 
drew the inspiration from solution proposed by @alex-aipolabs #485 
- Use `pull_request_target` instead of `pull_request`
- If the PR is from forked repo, we check out the PR's code (instead of defaulting to base branch's code)
- Due to the insecurity posed by previous step, for PR from forked repo, an approval is required from one of the ACI.dev member to run workflows.

### How to approve pending workflow
1. Go to `Actions` tab
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/68ca1d8d-dd22-4976-a4db-7aa597c6bd7d" />

2. Go to the waiting workflow run
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/31511bcb-62d2-48eb-ad95-ba55f41f54d8" />

3. Click "start all waiting jobs" and approve
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/d9352744-a1d0-4e28-8345-1a1963643c6e" />

