### PR TITLE
add more gitlab function(delete project and restore project)

### DIFF
--- a/backend/apps/gitlab/functions.json
+++ b/backend/apps/gitlab/functions.json
@@ -534,5 +534,95 @@
             ],
             "additionalProperties": false
         }
+    },
+    {
+        "name": "GITLAB__DELETE_PROJECT",
+        "description": "Deletes a project including all associated resources. The project is marked for deletion and deleted after 7 days by default. If the project is already marked for deletion, it will be deleted immediately (GitLab 15.11+).",
+        "tags": [
+            "project",
+            "delete"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/projects/{id}",
+            "server_url": "https://gitlab.com/api/v4"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters for the http request",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "The ID or URL-encoded path of the project"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ],
+                    "visible": [
+                        "id"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "GITLAB__RESTORE_PROJECT",
+        "description": "Restore a project that is marked for deletion",
+        "tags": [
+            "project",
+            "restore"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/projects/{id}/restore",
+            "server_url": "https://gitlab.com/api/v4"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters for the http request",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "The ID or URL-encoded path of the project"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ],
+                    "visible": [
+                        "id"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
     }
 ]


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description
Integrate more gitlab function
- GITLAB__DELETE_PROJECT
- GITLAB__RESTORE_PROJECT

```
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GITLAB__DELETE_PROJECT \
  --linked-account-owner-id jiwei@aipolabs.xyz \
  --aci-api-key e3d37ff0031c14793b5e4b5dcc824e1eefd84693dd85593e3a0bce1888294fc2 \
  --prompt "delete the project with id 70939215 "
```

```
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GITLAB__RESTORE_PROJECT \
  --linked-account-owner-id jiwei@aipolabs.xyz \
  --aci-api-key e3d37ff0031c14793b5e4b5dcc824e1eefd84693dd85593e3a0bce1888294fc2 \
  --prompt "restore the project with id 70939215"
```

### 📸 Screenshots (if applicable)
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/beceadd9-3e0a-4812-a74e-efed2b54df31" />
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/2b3e97a7-a74e-496d-8cd8-e9cd9f112f72" />

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [x] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete a project and all its resources via the API.
  - Introduced an option to restore projects that are marked for deletion through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->