### PR TITLE
Feat: Integration of Supabase Functions

### DIFF
--- a/backend/apps/supabase/functions.json
+++ b/backend/apps/supabase/functions.json
@@ -877,5 +877,333 @@
             "visible": ["path", "body"],
             "additionalProperties": false
         }
+    },
+    {
+        "name": "SUPABASE__LIST_ALL_EDGE_FUNCTIONS",
+        "description": "List all edge functions",
+        "tags": ["edge", "functions", "list"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v1/projects/{ref}/functions",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        }
+                    },
+                    "required": ["ref"],
+                    "visible": ["ref"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "SUPABASE__CREATE_EDGE_FUNCTION",
+        "description": "Create an edge function (deprecated - use deploy endpoint)",
+        "tags": ["edge", "functions", "create"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/v1/projects/{ref}/functions",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        }
+                    },
+                    "required": ["ref"],
+                    "visible": ["ref"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "query parameters",
+                    "properties": {
+                        "import_map_path": {
+                            "type": "string",
+                            "description": "Import map path"
+                        },
+                        "entrypoint_path": {
+                            "type": "string",
+                            "description": "Entrypoint path"
+                        },
+                        "import_map": {
+                            "type": "boolean",
+                            "description": "Import map enabled"
+                        },
+                        "verify_jwt": {
+                            "type": "boolean",
+                            "description": "Verify JWT"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Function name"
+                        },
+                        "slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["import_map_path", "entrypoint_path", "import_map", "verify_jwt", "name", "slug"],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "body parameters",
+                    "properties": {
+                        "slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Function name"
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Function code body"
+                        },
+                        "verify_jwt": {
+                            "type": "boolean",
+                            "description": "Verify JWT"
+                        }
+                    },
+                    "required": ["slug", "name", "body"],
+                    "visible": ["slug", "name", "body", "verify_jwt"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path", "body"],
+            "visible": ["path", "query", "body"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "SUPABASE__DELETE_EDGE_FUNCTION",
+        "description": "Delete an edge function",
+        "tags": ["edge", "functions", "delete"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/v1/projects/{ref}/functions/{function_slug}",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        },
+                        "function_slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        }
+                    },
+                    "required": ["ref", "function_slug"],
+                    "visible": ["ref", "function_slug"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "SUPABASE__GET_EDGE_FUNCTION",
+        "description": "Get an edge function",
+        "tags": ["edge", "functions", "get"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v1/projects/{ref}/functions/{function_slug}",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        },
+                        "function_slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        }
+                    },
+                    "required": ["ref", "function_slug"],
+                    "visible": ["ref", "function_slug"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "SUPABASE__UPDATE_EDGE_FUNCTION",
+        "description": "Update an edge function",
+        "tags": ["edge", "functions", "update"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PATCH",
+            "path": "/v1/projects/{ref}/functions/{function_slug}",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        },
+                        "function_slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        }
+                    },
+                    "required": ["ref", "function_slug"],
+                    "visible": ["ref", "function_slug"],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "query parameters",
+                    "properties": {
+                        "import_map_path": {
+                            "type": "string",
+                            "description": "Import map path"
+                        },
+                        "entrypoint_path": {
+                            "type": "string",
+                            "description": "Entrypoint path"
+                        },
+                        "import_map": {
+                            "type": "boolean",
+                            "description": "Import map enabled"
+                        },
+                        "verify_jwt": {
+                            "type": "boolean",
+                            "description": "Verify JWT"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Function name"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["import_map_path", "entrypoint_path", "import_map", "verify_jwt", "name"],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "body parameters",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Function name"
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Function code body"
+                        },
+                        "verify_jwt": {
+                            "type": "boolean",
+                            "description": "Verify JWT"
+                        }
+                    },
+                    "required": [],
+                    "visible": ["name", "body", "verify_jwt"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path", "query", "body"],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "SUPABASE__GET_EDGE_FUNCTION_BODY",
+        "description": "Get an edge function body",
+        "tags": ["edge", "functions", "body", "get"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/v1/projects/{ref}/functions/{function_slug}/body",
+            "server_url": "https://api.supabase.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "path parameters",
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Project ref"
+                        },
+                        "function_slug": {
+                            "type": "string",
+                            "description": "Function slug"
+                        }
+                    },
+                    "required": ["ref", "function_slug"],
+                    "visible": ["ref", "function_slug"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
+            "visible": ["path"],
+            "additionalProperties": false
+        }
     }
 ]


### PR DESCRIPTION
### 🏷️ Ticket

N/A

### 📝 Description

Integrated 6 Supabase functions:

* `SUPABASE__LIST_ALL_EDGE_FUNCTIONS`: List all edge functions
* `SUPABASE__CREATE_EDGE_FUNCTION`: Create an edge function
* `SUPABASE__DELETE_EDGE_FUNCTION`: Delete an edge function
* `SUPABASE__GET_EDGE_FUNCTION`: Get an edge function
* `SUPABASE__UPDATE_EDGE_FUNCTION`: Update an edge function
* `SUPABASE__GET_EDGE_FUNCTION_BODY`: Get an edge function body

fuzzy test prompts:
```
### List All Edge Functions
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name SUPABASE__LIST_ALL_EDGE_FUNCTIONS \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a49xxxx4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "List all edge functions in the Supabase project with reference 'wptjuuumtkybsgxqujxm'. Show me function names, slugs, status, versions, and creation dates."


### Create Edge Function (Deprecated)
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name SUPABASE__CREATE_EDGE_FUNCTION \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a49xxxx4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Create a new edge function named 'hello-world' with slug 'hello-world' in project 'wptjuuumtkybsgxqujxm'. Function body should return a simple 'Hello World' response. Enable JWT verification."

### Get Edge Function Details
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name SUPABASE__GET_EDGE_FUNCTION \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a49xxxx4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Get details for the edge function with slug 'hello-world' in project 'wptjuuumtkybsgxqujxm'. Show me function metadata, status, version, and configuration."

### Update Edge Function
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name SUPABASE__UPDATE_EDGE_FUNCTION \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a49xxxx4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Update the edge function 'hello-world' in project 'wptjuuumtkybsgxqujxm'. Change the function name to 'hello-world-v2' and disable JWT verification."

### Get Edge Function Body/Code
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name SUPABASE__GET_EDGE_FUNCTION_BODY \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a49xxxx4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Get the source code body for the edge function with slug 'hello-world' in project 'wptjuuumtkybsgxqujxm'."
```

please replace `linked-account-owner-id` and `aci-api-key` to your own value. These values only exist on my local test case.

### 🎥 Demo (if applicable)

N/A

### 📸 Screenshots (if applicable)

https://www.notion.so/GitLab-2188378d6a47806589fff9fdec82ba8b?source=copy_link

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [x] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new REST API endpoints for managing edge functions in Supabase projects, including listing, retrieving, updating, deleting, and fetching function code.
	- Added support for parameterized requests and enhanced control over function metadata and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->