### PR TITLE
feat: show linked accounts count on app card in app store page

### DIFF
--- a/frontend/src/__tests__/app/apps/page.test.tsx
+++ b/frontend/src/__tests__/app/apps/page.test.tsx
@@ -2,12 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import AppStorePage from "@/app/apps/page";
 import { useApps } from "@/hooks/use-app";
+import { useAppLinkedAccounts } from "@/hooks/use-linked-account";
 import { App } from "@/lib/types/app";
 import { UseQueryResult } from "@tanstack/react-query";
 
 // Mock the useApps hook
 vi.mock("@/hooks/use-app", () => ({
   useApps: vi.fn(),
+}));
+
+// Mock the useAppLinkedAccounts hook
+vi.mock("@/hooks/use-linked-account", () => ({
+  useAppLinkedAccounts: vi.fn(),
 }));
 
 describe("AppStorePage", () => {
@@ -82,6 +88,35 @@ describe("AppStorePage", () => {
       refetch: vi.fn(),
       error: null,
     } as unknown as UseQueryResult<App[], Error>);
+
+    vi.mocked(useAppLinkedAccounts).mockReturnValue({
+      data: [
+        {
+          id: "1",
+          app_name: "TEST_APP_1",
+          project_id: "1",
+          linked_account_owner_id: "1",
+          security_scheme: "oauth2",
+          enabled: true,
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+          last_used_at: null,
+        },
+        {
+          id: "2",
+          app_name: "TEST_APP_1",
+          project_id: "1",
+          linked_account_owner_id: "1121",
+          security_scheme: "oauth2",
+          enabled: true,
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+          last_used_at: null,
+        },
+      ],
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useAppLinkedAccounts>);
 
     render(<AppStorePage />);
     screen.logTestingPlaygroundURL();

--- a/frontend/src/components/apps/app-card.tsx
+++ b/frontend/src/components/apps/app-card.tsx
@@ -16,12 +16,15 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "@/components/ui/tooltip";
+import { useAppLinkedAccounts } from "@/hooks/use-linked-account";
 
 interface AppCardProps {
   app: App;
 }
 
 export function AppCard({ app }: AppCardProps) {
+  const { data: linkedAccounts = [] } = useAppLinkedAccounts(app.name);
+
   return (
     <Link href={`/apps/${app.name}`} className="block">
       <Card className="h-[300px] transition-shadow hover:shadow-lg flex flex-col overflow-hidden ]">
@@ -78,6 +81,18 @@ export function AppCard({ app }: AppCardProps) {
                 <TooltipContent>
                   <p className="text-xs">
                     {`Functions in This App: ${app.functions.length}`}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-sm bg-blue-100 px-2.5 py-1 font-medium text-blue-600 border rounded-full border-blue-200">
+                    {linkedAccounts.length}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-xs">
+                    {`Linked Accounts: ${linkedAccounts.length}`}
                   </p>
                 </TooltipContent>
               </Tooltip>


### PR DESCRIPTION
### 🏷️ Ticket

[notion](https://www.notion.so/fbce3fc996ad4b2aaacd85d0492a48d7?v=c135b6e7f76243819caf99a83e291380&p=1e98378d6a47807f9f32e9aeb4326802&pm=s)

### 📝 Description

Use useAppLinkedAccounts into AppCard to retrieve the linkedAccounts array and its length.
Added a badge with a Tooltip at the bottom-right corner of the card showing linkedAccounts.length.
Add mock hook in test

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)
https://files.slack.com/files-pri/T08H769MXJ6-F092KS11Q0P/image.png
### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
