### PR TITLE
Integration: Updated Google Sheets' Scopes

### DIFF
--- a/backend/apps/google_sheets/app.json
+++ b/backend/apps/google_sheets/app.json
@@ -12,7 +12,7 @@
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_SHEETS_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_SHEETS_CLIENT_SECRET }}",
-      "scope": "https://www.googleapis.com/auth/spreadsheets",
+      "scope": "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
       "access_token_url": "https://oauth2.googleapis.com/token",
       "refresh_token_url": "https://oauth2.googleapis.com/token"


### PR DESCRIPTION
### 🏷️ Ticket

N/A

### 📝 Description

Updated several scopes in `google_sheet/app.json` and tests all the functions properly.

Fuzzy test prompts
```
# Create spreadsheet using GOOGLE_SHEETS__SPREADSHEET_CREATE 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_SHEETS__SPREADSHEET_CREATE \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Create a new spreadsheet called 'Grades'"

# Initial the value using GOOGLE_SHEETS__VALUES_UPDATE 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_SHEETS__VALUES_UPDATE \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "In spreadsheet '1-El4Mtk_0X_Ek9N_A3QxwV1O1SObIIW-zf7hnWjS2go', set up the data starting from A1 with headers 'names' and 'score' in the first row, then add the data: Alan with score 80, James with score 95, and Tony with score 100"
  
# Get value using GOOGLE_SHEETS__VALUES_GET 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_SHEETS__VALUES_GET \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "Get James's score from spreadsheet '1-El4Mtk_0X_Ek9N_A3QxwV1O1SObIIW-zf7hnWjS2go' in Sheet1"
  
# Update James's score to 100 using GOOGLE_SHEETS__VALUES_UPDATE 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
   --function-name GOOGLE_SHEETS__VALUES_UPDATE \
   --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
   --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
   --prompt "In spreadsheet '1-El4Mtk_0X_Ek9N_A3QxwV1O1SObIIW-zf7hnWjS2go', update James's score (which should be in row 3, column B of Sheet1) to 100"

# All score +5 using GOOGLE_SHEETS__VALUES_BATCH_UPDATE 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_SHEETS__VALUES_BATCH_UPDATE \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "In spreadsheet '1-El4Mtk_0X_Ek9N_A3QxwV1O1SObIIW-zf7hnWjS2go', update three rows in column B (B2, B3, B4) with values 85, 100, 105 respectively, using ROWS dimension"
 
# Append Theo's score using GOOGLE_SHEETS__VALUES_APPEND 
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name GOOGLE_SHEETS__VALUES_APPEND \
  --linked-account-owner-id 21582c88-d693-44fc-bbc5-b34eab120d7e \
  --aci-api-key 76658ac19a2afe8670abec0abf3c54a4966cc4bdfe05eec821cdbb7de1c21aa7 \
  --prompt "In spreadsheet '1-El4Mtk_0X_Ek9N_A3QxwV1O1SObIIW-zf7hnWjS2go', append a new row with Theo's name and score of 60"
```

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

Fuzzy test result screenshots:
https://www.notion.so/Google-Integration-scope-fix-2228378d6a478075a691df6f232b4597?source=copy_link

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
