### PR TITLE
feat: add close button to toast notifications

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -116,7 +116,15 @@ export default function RootLayout({
           </RequiredAuthProvider>
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
-        <Toaster />
+        <Toaster
+          closeButton
+          toastOptions={{
+            classNames: {
+              closeButton:
+                "!text-gray-600 hover:!text-red-500 !h-6 !w-6 !bg-white hover:!bg-red-50 !rounded !border !border-gray-200 hover:!border-red-200 !transition-colors !duration-150",
+            },
+          }}
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

Adds a small “×” close button to the bottom-right toast notifications so users can dismiss them immediately, preventing the toast from blocking underlying UI elements.


### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
