### PR TITLE
Feat/expose oauth2 tokens

### DIFF
--- a/backend/aci/common/schemas/linked_accounts.py
+++ b/backend/aci/common/schemas/linked_accounts.py
@@ -5,7 +5,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from aci.common.db.sql_models import MAX_STRING_LENGTH, SecurityScheme
 from aci.common.schemas.security_scheme import (
-    NoAuthSchemeCredentials,
+    APIKeySchemeCredentialsLimited,
+    NoAuthSchemeCredentialsLimited,
+    OAuth2SchemeCredentialsLimited,
 )
 
 
@@ -57,26 +59,16 @@ class LinkedAccountPublic(BaseModel):
     enabled: bool
     created_at: datetime
     updated_at: datetime
-    last_used_at: datetime | None
+    last_used_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
 
-class OAuth2SchemeCredentialsLimited(BaseModel):
-    """Limited OAuth2 credentials containing only access token"""
-
-    access_token: str
-
-
-class APIKeySchemeCredentialsLimited(BaseModel):
-    """Limited API key credentials containing only secret key"""
-
-    secret_key: str
-
-
 class LinkedAccountWithCredentials(LinkedAccountPublic):
     security_credentials: (
-        OAuth2SchemeCredentialsLimited | APIKeySchemeCredentialsLimited | NoAuthSchemeCredentials
+        OAuth2SchemeCredentialsLimited
+        | APIKeySchemeCredentialsLimited
+        | NoAuthSchemeCredentialsLimited
     )
 
 

--- a/backend/aci/common/schemas/security_scheme.py
+++ b/backend/aci/common/schemas/security_scheme.py
@@ -162,6 +162,15 @@ class APIKeySchemeCredentials(BaseModel):
     secret_key: str
 
 
+class APIKeySchemeCredentialsLimited(BaseModel):
+    """
+    Limited API key credentials to expose to the client directly
+    Placeholder for now just to be consistent with OAuth2SchemeCredentialsLimited
+    """
+
+    pass
+
+
 class OAuth2SchemeCredentials(BaseModel):
     """Credentials for OAuth2 scheme"""
 
@@ -180,12 +189,29 @@ class OAuth2SchemeCredentials(BaseModel):
     raw_token_response: dict | None = None
 
 
+class OAuth2SchemeCredentialsLimited(BaseModel):
+    """Limited OAuth2 credentials to expose to the client directly"""
+
+    access_token: str
+    expires_at: int | None = None
+    refresh_token: str | None = None
+
+
 class NoAuthSchemeCredentials(BaseModel, extra="forbid"):
     """
     Credentials for no auth scheme
     For now it only allows an empty dict, this is clearer and less ambiguous than using {} or None directly.
     We could also add some fields as metadata in the future if needed.
     # TODO: there is some ambiguity with "no auth" and "use app's default credentials", needs a refactor.
+    """
+
+    pass
+
+
+class NoAuthSchemeCredentialsLimited(BaseModel, extra="forbid"):
+    """
+    Limited no auth credentials to expose to the client directly
+    Placeholder for now just to be consistent with OAuth2SchemeCredentialsLimited
     """
 
     pass

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -587,7 +587,11 @@ async def list_linked_accounts(
     return linked_accounts
 
 
-@router.get("/{linked_account_id}", response_model=LinkedAccountWithCredentials)
+@router.get(
+    "/{linked_account_id}",
+    response_model=LinkedAccountWithCredentials,
+    response_model_exclude_none=True,
+)
 async def get_linked_account(
     context: Annotated[deps.RequestContext, Depends(deps.get_request_context)],
     linked_account_id: UUID,

--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -402,7 +402,8 @@ async def link_oauth2_account(
 @router.get(
     "/oauth2/callback",
     name=LINKED_ACCOUNTS_OAUTH2_CALLBACK_ROUTE_NAME,
-    response_model=LinkedAccountPublic,
+    response_model=LinkedAccountWithCredentials,
+    response_model_exclude_none=True,
 )
 async def linked_accounts_oauth2_callback(
     request: Request,

--- a/backend/aci/server/tests/routes/linked_acounts/test_accounts_link_oauth2.py
+++ b/backend/aci/server/tests/routes/linked_acounts/test_accounts_link_oauth2.py
@@ -19,7 +19,7 @@ from aci.common.schemas.app_configurations import (
 from aci.common.schemas.linked_accounts import (
     LinkedAccountOAuth2Create,
     LinkedAccountOAuth2CreateState,
-    LinkedAccountPublic,
+    LinkedAccountWithCredentials,
 )
 from aci.common.schemas.security_scheme import (
     OAuth2SchemeCredentials,
@@ -180,8 +180,19 @@ def test_link_oauth2_account_success(
             )
 
         if not after_oauth2_link_redirect_url:
-            assert LinkedAccountPublic.model_validate(response.json()), (
-                "should return linked account in response if after_oauth2_link_redirect_url is not provided"
+            assert LinkedAccountWithCredentials.model_validate(response.json()), (
+                "should return linked account with credentials in response if after_oauth2_link_redirect_url is not provided"
+            )
+            security_credentials = response.json()["security_credentials"]
+            assert (
+                security_credentials["access_token"] == mock_oauth2_token_response["access_token"]
+            )
+            # NOTE: expires_at and refresh_token are optional, but they exist in this mock linked account
+            assert security_credentials["expires_at"] == mock_oauth2_token_retrieval_time + cast(
+                int, mock_oauth2_token_response["expires_in"]
+            )
+            assert (
+                security_credentials["refresh_token"] == mock_oauth2_token_response["refresh_token"]
             )
 
 


### PR DESCRIPTION
### 📝 Description

- improve db session creation code (avoid connection overhead)
- expose refresh token & expire_at (in addition to access_token) for get linked account request (but not list linked accounts)
- expose oauth2 credentials in oauth2/callback
- update tests accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses for linked account endpoints now include limited credential details, such as OAuth2 tokens, where applicable.

* **Improvements**
  * Responses from linked account endpoints now exclude fields with no values, resulting in cleaner and more concise output.
  * Optimized database connection handling to improve performance and reliability.

* **Bug Fixes**
  * Tests updated to validate the new response structure and credential exposure for linked accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->