### PR TITLE
Project name for aci

### DIFF
--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -44,16 +44,16 @@ services:
     volumes:
       - ./scripts/create-kms-encryption-key.sh:/etc/localstack/init/ready.d/create-kms-encryption-key.sh
 
-  # propelauth_mock:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile.runner
-  #   ports:
-  #     - "12800:12800"
-  #   working_dir: /workdir
-  #   volumes:
-  #     - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
-  #   command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800 --reload
+  propelauth_mock:
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    ports:
+      - "12800:12800"
+    working_dir: /workdir
+    volumes:
+      - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
+    command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800 --reload
 
   server:
     build:
@@ -72,7 +72,7 @@ services:
       - ./aci/server:/workdir/aci/server
       - ./aci/common:/workdir/aci/common
       # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
-      # - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     ports:
       - "8000:8000"
     # this overrides the default CMD specified in the Dockerfile, use this for local development
@@ -100,7 +100,7 @@ services:
       - ./evals:/workdir/evals
       - ./alembic.ini:/workdir/alembic.ini
       # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
-      # - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
+      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     command: >
       /bin/sh -c "alembic upgrade head && tail -f /dev/null"
     depends_on:

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -1,3 +1,5 @@
+name: aci
+
 services:
   db:
     # Note: we need to use the pgvector/pgvector:pg17 image to use the pgvector extension, instead of the official postgres image
@@ -42,16 +44,16 @@ services:
     volumes:
       - ./scripts/create-kms-encryption-key.sh:/etc/localstack/init/ready.d/create-kms-encryption-key.sh
 
-  propelauth_mock:
-    build:
-      context: .
-      dockerfile: Dockerfile.runner
-    ports:
-      - "12800:12800"
-    working_dir: /workdir
-    volumes:
-      - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
-    command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800 --reload
+  # propelauth_mock:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.runner
+  #   ports:
+  #     - "12800:12800"
+  #   working_dir: /workdir
+  #   volumes:
+  #     - ./mock/propelauth_mock_server.py:/workdir/propelauth_mock_server.py
+  #   command: uvicorn propelauth_mock_server:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 12800 --reload
 
   server:
     build:
@@ -70,7 +72,7 @@ services:
       - ./aci/server:/workdir/aci/server
       - ./aci/common:/workdir/aci/common
       # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
-      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
+      # - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     ports:
       - "8000:8000"
     # this overrides the default CMD specified in the Dockerfile, use this for local development
@@ -98,7 +100,7 @@ services:
       - ./evals:/workdir/evals
       - ./alembic.ini:/workdir/alembic.ini
       # Mocks out the propelauth_fastapi module in server container to bypass token validation in local development
-      - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
+      # - ./mock/propelauth_fastapi_mock.py:/workdir/.venv/lib/python3.12/site-packages/propelauth_fastapi/__init__.py
     command: >
       /bin/sh -c "alembic upgrade head && tail -f /dev/null"
     depends_on:


### PR DESCRIPTION
### 📝 Description

Provide a name for the docker compose project so it doesn't interfere with other projects which are under a `backend` folder

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set the Docker Compose project name to "aci" to prevent conflicts with other projects in the backend folder. 

- **Refactors**
  - Added the name field to compose.yml.
  - Commented out unused mock service and volume mounts.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration with a project name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->