### PR TITLE
Adjust allowed apps dialog size

### DIFF
--- a/frontend/src/components/project/app-edit-form.tsx
+++ b/frontend/src/components/project/app-edit-form.tsx
@@ -104,7 +104,7 @@ export function AppEditForm({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="sm:max-w-[425px] ">
+      <DialogContent className="sm:max-w-[600px] ">
         <DialogHeader className="space-y-4">
           <div className="flex items-center justify-between">
             <DialogTitle>Edit Allowed Apps</DialogTitle>
@@ -141,7 +141,7 @@ export function AppEditForm({
                 <p>No app configurations available</p>
               </div>
             ) : (
-              <div className="max-h-[45vh] overflow-y-auto">
+              <div className="max-h-[60vh] overflow-y-auto">
                 <EnhancedDataTable
                   columns={columns}
                   data={appConfigs}


### PR DESCRIPTION
## Summary
- increase width of Edit Allowed Apps dialog
- expand the table area to show more entries

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883f9b090d08333a35f74a384842be5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increased the width of the Edit Allowed Apps dialog and expanded the table area to show more entries.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the maximum width of the dialog for a wider layout on small screens.
  * Expanded the maximum height of the scrollable container to show more app configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->