### PR TITLE
Remove subscription limits from pricing page

### DIFF
--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -30,10 +30,7 @@ const tiers = [
     features: [
       "1 Project",
       "10 Unique End Users",
-      "1K API calls/month",
-      "5 Agent Credentials",
       "1 Developer Seat",
-      "Custom OAuth2 Client",
       "3 Days Log Retention",
     ],
     buttonText: "Start for Free",
@@ -49,10 +46,7 @@ const tiers = [
     features: [
       "5 Projects",
       "250 Unique End Users",
-      "100K API calls/month",
-      "2500 Agent Credentials",
       "5 Developer Seats",
-      "Custom OAuth2 Client",
       "1 Week Log Retention",
     ],
     buttonText: "Get Started",
@@ -68,10 +62,7 @@ const tiers = [
     features: [
       "10 Projects",
       "1000 Unique End Users",
-      "300K API calls/month",
-      "10000 Agent Credentials",
       "10 Developer Seats",
-      "Custom OAuth2 Client",
       "1 Month Log Retention",
     ],
     mostPopular: true,
@@ -86,10 +77,7 @@ const tiers = [
     features: [
       "Custom Projects",
       "Custom Unique End User Accounts",
-      "Custom API Calls",
-      "Unlimited Agent Credentials",
       "Custom Developer Seats",
-      "Custom OAuth2 Client",
       "Custom Log Retention",
     ],
     buttonText: "Contact Us",


### PR DESCRIPTION
## Summary
- clean up the pricing tiers to remove credential, API, and OAuth references

## Testing
- `npm run lint`
- `npm test` *(fails: waiting for file changes, canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6883fd863bdc833395ae27c85edb45d4
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed all references to subscription limits for API calls, agent credentials, and OAuth from the pricing page to simplify plan details.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the pricing page to remove references to API call limits, agent credentials, and custom OAuth2 client support from all pricing tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->