### PR TITLE
Fix app card layout overflow issue with min-width constraint

### DIFF
--- a/frontend/src/components/apps/app-card.tsx
+++ b/frontend/src/components/apps/app-card.tsx
@@ -52,7 +52,7 @@ export function AppCard({ app, isConfigured = false }: AppCardProps) {
         )}
 
         <CardHeader className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between min-w-0">
             <div className="flex items-center gap-3 min-w-0 flex-1 mr-4">
               <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg">
                 <Image


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

Fixed app card layout overflow issue by adding min-width constraint to prevent text wrapping issues in the app card component.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an overflow issue in the app card layout by adding a min-width constraint to prevent text wrapping problems.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout handling for app cards to better manage content overflow and ensure consistent display of app titles and IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->