### PR TITLE
fix prefix error

### DIFF
--- a/backend/apps/supabase/app.json
+++ b/backend/apps/supabase/app.json
@@ -9,7 +9,7 @@
     "api_key": {
       "location": "header",
       "name": "Authorization",
-      "prefix": "Bearer "
+      "prefix": "Bearer"
     }
   },
   "default_security_credentials_by_scheme": {},


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Debug-Supabase-Integration-2418378d6a47801589f8dfc3f796b58e?source=copy_link

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the "Bearer" prefix in the Supabase API key configuration to remove the extra space and ensure correct authentication.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Authorization header prefix in the API key security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->