### PR TITLE
docs: fixing minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ACI.dev improves tool-calling reliability and accountability:
 - **Documentation:** [aci.dev/docs](https://www.aci.dev/docs)
 - **Available Tools List:** [aci.dev/tools](https://www.aci.dev/tools)
 - **Python SDK:** [github.com/aipotheosis-labs/aci-python-sdk](https://github.com/aipotheosis-labs/aci-python-sdk)
-- **Typescript SDK:** [github.com/aipotheosis-labs/aci-python-sdk](https://github.com/aipotheosis-labs/aci-typescript-sdk)
+- **Typescript SDK:** [github.com/aipotheosis-labs/aci-typescript-sdk](https://github.com/aipotheosis-labs/aci-typescript-sdk)
 - **Unified MCP Server:** [github.com/aipotheosis-labs/aci-mcp](https://github.com/aipotheosis-labs/aci-mcp)
 - **Agent Examples Built with ACI.dev:** [github.com/aipotheosis-labs/aci-agents](https://github.com/aipotheosis-labs/aci-agents)
 - **Blog:** [aci.dev/blog](https://www.aci.dev/blog)


### PR DESCRIPTION
Fixing a minor typo in README

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a typo in the README by correcting the Typescript SDK link.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the link to the Typescript SDK in the Quick Links section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->