### PR TITLE
feat(integration): x.com oauth2 & slim state (drop redirect_url)

### DIFF
--- a/backend/aci/common/schemas/linked_accounts.py
+++ b/backend/aci/common/schemas/linked_accounts.py
@@ -44,7 +44,7 @@ class LinkedAccountOAuth2CreateState(BaseModel):
     # because we support custom client ID, and user may have changed the client ID after the flow starts.
     # (e.g., delete and recreate app configuration. Even though this is rare.)
     client_id: str
-    redirect_uri: str
+    redirect_uri: str | None = None
     code_verifier: str
     after_oauth2_link_redirect_url: str | None = None
 

--- a/backend/apps/x_com/app.json
+++ b/backend/apps/x_com/app.json
@@ -6,10 +6,16 @@
   "version": "1.0.0",
   "description": "X API v2 integration for accessing posts, users, communities, trends, and social interactions. Provides programmatic access to X's global conversation with real-time data and advanced analytics.",
   "security_schemes": {
-    "api_key": {
+    "oauth2": {
       "location": "header",
       "name": "Authorization",
-      "prefix": "Bearer"
+      "prefix": "Bearer",
+      "client_id": "{{ AIPOLABS_X_COM_CLIENT_ID }}",
+      "client_secret": "{{ AIPOLABS_X_COM_CLIENT_SECRET }}",
+      "scope": "tweet.read tweet.write users.read follows.read follows.write like.read like.write bookmark.read bookmark.write list.read list.write mute.read mute.write block.read block.write space.read tweet.moderate.write offline.access",
+      "authorize_url": "https://x.com/i/oauth2/authorize",
+      "access_token_url": "https://api.x.com/2/oauth2/token",
+      "refresh_token_url": "https://api.x.com/2/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},


### PR DESCRIPTION
### 🏷️ Ticket

https://www.notion.so/X-com-integration-OAuth-2-0-integration-2468378d6a478061958bc6b1dd5c4a7c?source=copy_link

### 📝 Description

This PR is to fix the error that x.com oauth2 integration doesn't work in ACI

I made some changes in `backend/aci/server/routes/linked_accounts.py` and `backend/aci/common/schemas/linked_accounts.py` and it works now.

Changes I made:
- Shortened the OAuth2 state we send to providers to reduce the risk of `invalid_request` errors due to state size limits (e.g., x.com ~500 chars - [source: Why is there a state paramter limit for OAuth2 authorization requests? - X developers forum](https://devcommunity.x.com/t/why-is-there-a-state-paramter-limit-for-oauth2-authorization-requests/164824)).
- Made `redirect_uri` optional in the state model (str | None = None) and recompute it on callback instead of embedding it in state.
- Rewrite the `security_schemes` part in `x_com/app.json`, change it to `oauth2` and using correct scopes

### 🎥 Demo (if applicable)

N/A

### 📸 Screenshots (if applicable)

check the notion link for it

### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [x] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
