### PR TITLE
refactor x.com support oauth integration

### DIFF
--- a/backend/aci/common/schemas/linked_accounts.py
+++ b/backend/aci/common/schemas/linked_accounts.py
@@ -44,7 +44,7 @@ class LinkedAccountOAuth2CreateState(BaseModel):
     # because we support custom client ID, and user may have changed the client ID after the flow starts.
     # (e.g., delete and recreate app configuration. Even though this is rare.)
     client_id: str
-    redirect_uri: str
+    redirect_uri: str | None = None
     code_verifier: str
     after_oauth2_link_redirect_url: str | None = None
 

--- a/backend/aci/server/oauth2_manager.py
+++ b/backend/aci/server/oauth2_manager.py
@@ -2,11 +2,13 @@ import random
 import string
 import time
 from typing import Any, cast
+from uuid import UUID
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 
 from aci.common.exceptions import OAuth2Error
 from aci.common.logging_setup import get_logger
+from aci.common.schemas.linked_accounts import LinkedAccountOAuth2CreateState
 from aci.common.schemas.security_scheme import OAuth2SchemeCredentials
 
 UNICODE_ASCII_CHARACTER_SET = string.ascii_letters + string.digits
@@ -110,6 +112,44 @@ class OAuth2Manager:
         )
 
         return str(authorization_url)
+
+    def create_oauth2_state(
+        self,
+        project_id: UUID,
+        linked_account_owner_id: str,
+        client_id: str,
+        redirect_uri: str,
+        after_oauth2_link_redirect_url: str | None = None,
+    ) -> LinkedAccountOAuth2CreateState:
+        """
+        Create OAuth2 state for authorization flow.
+        Special case: X_COM app will have redirect_uri set to None.
+
+        Args:
+            project_id: The project ID
+            linked_account_owner_id: The linked account owner ID
+            client_id: The OAuth2 client ID
+            redirect_uri: The redirect URI for OAuth2 callback
+            after_oauth2_link_redirect_url: Optional URL to redirect to after linking
+
+        Returns:
+            LinkedAccountOAuth2CreateState object
+        """
+        oauth2_state = LinkedAccountOAuth2CreateState(
+            app_name=self.app_name,
+            project_id=project_id,
+            linked_account_owner_id=linked_account_owner_id,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_verifier=self.generate_code_verifier(),
+            after_oauth2_link_redirect_url=after_oauth2_link_redirect_url,
+        )
+
+        # Special case: X_COM app should not store redirect_uri in state
+        if self.app_name == "X_COM":
+            del oauth2_state.redirect_uri
+
+        return oauth2_state
 
     # TODO: some app may not support "code_verifier"?
     async def fetch_token(

--- a/backend/apps/x_com/app.json
+++ b/backend/apps/x_com/app.json
@@ -6,10 +6,16 @@
   "version": "1.0.0",
   "description": "X API v2 integration for accessing posts, users, communities, trends, and social interactions. Provides programmatic access to X's global conversation with real-time data and advanced analytics.",
   "security_schemes": {
-    "api_key": {
+    "oauth2": {
       "location": "header",
       "name": "Authorization",
-      "prefix": "Bearer"
+      "prefix": "Bearer",
+      "client_id": "{{ AIPOLABS_X_COM_CLIENT_ID }}",
+      "client_secret": "{{ AIPOLABS_X_COM_CLIENT_SECRET }}",
+      "scope": "tweet.read tweet.write users.read follows.read follows.write like.read like.write bookmark.read bookmark.write list.read list.write mute.read mute.write block.read block.write space.read tweet.moderate.write offline.access",
+      "authorize_url": "https://x.com/i/oauth2/authorize",
+      "access_token_url": "https://api.x.com/2/oauth2/token",
+      "refresh_token_url": "https://api.x.com/2/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},
@@ -20,4 +26,4 @@
   ],
   "visibility": "public",
   "active": true
-} 
+}

--- a/backend/apps/x_com/functions.json
+++ b/backend/apps/x_com/functions.json
@@ -1055,12 +1055,41 @@
           "properties": {
             "text": {
               "type": "string",
-              "description": "The content of the post. Required if media is not provided.",
-              "maxLength": 280
+              "description": "The content of the Tweet."
+            },
+            "card_uri": {
+              "type": "string",
+              "description": "Card Uri Parameter. This is mutually exclusive from Quote Tweet Id, Poll, Media, and Direct Message Deep Link."
+            },
+            "community_id": {
+              "type": "string",
+              "description": "The unique identifier of this Community."
+            },
+            "direct_message_deep_link": {
+              "type": "string",
+              "description": "Link to take the conversation from the public timeline to a private Direct Message."
+            },
+            "for_super_followers_only": {
+              "type": "boolean",
+              "description": "Exclusive Tweet for super followers.",
+              "default": false
+            },
+            "geo": {
+              "type": "object",
+              "description": "Place ID being attached to the Tweet for geo location.",
+              "properties": {
+                "place_id": {
+                  "type": "string",
+                  "description": "Place ID for the location"
+                }
+              },
+              "required": [],
+              "visible": ["place_id"],
+              "additionalProperties": false
             },
             "media": {
               "type": "object",
-              "description": "Media to attach to the post",
+              "description": "Media information being attached to created Tweet. This is mutually exclusive from Quote Tweet Id, Poll, and Card URI.",
               "properties": {
                 "media_ids": {
                   "type": "array",
@@ -1081,9 +1110,14 @@
               "visible": ["media_ids", "tagged_user_ids"],
               "additionalProperties": false
             },
+            "nullcast": {
+              "type": "boolean",
+              "description": "Nullcasted (promoted-only) Posts do not appear in the public timeline and are not served to followers.",
+              "default": false
+            },
             "poll": {
               "type": "object",
-              "description": "Poll to include in the post",
+              "description": "Poll options for a Tweet with a poll. This is mutually exclusive from Media, Quote Tweet Id, and Card URI.",
               "properties": {
                 "options": {
                   "type": "array",
@@ -1101,60 +1135,47 @@
                   "description": "Poll duration in minutes (5 minutes to 7 days)"
                 }
               },
-              "required": ["options", "duration_minutes"],
+              "required": [],
               "visible": ["options", "duration_minutes"],
               "additionalProperties": false
             },
+            "quote_tweet_id": {
+              "type": "string",
+              "description": "Unique identifier of this Tweet. This is returned as a string in order to avoid complications with languages and tools that cannot handle large integers."
+            },
             "reply": {
               "type": "object",
-              "description": "Reply settings for the post",
+              "description": "Tweet information of the Tweet being replied to.",
               "properties": {
                 "in_reply_to_tweet_id": {
                   "type": "string",
-                  "description": "ID of the post being replied to"
+                  "description": "Unique identifier of this Tweet. This is returned as a string in order to avoid complications with languages and tools that cannot handle large integers."
                 },
                 "exclude_reply_user_ids": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
-                  "description": "User IDs to exclude from reply notifications"
+                  "description": "A list of User Ids to be excluded from the reply Tweet."
                 }
               },
               "required": [],
               "visible": ["in_reply_to_tweet_id", "exclude_reply_user_ids"],
               "additionalProperties": false
             },
-            "quote_tweet_id": {
-              "type": "string",
-              "description": "ID of the post being quoted"
-            },
             "reply_settings": {
               "type": "string",
-              "enum": ["everyone", "mentionedUsers", "following"],
-              "description": "Who can reply to this post"
+              "enum": ["following", "mentionedUsers", "subscribers", "verified"],
+              "description": "Settings to indicate who can reply to the Tweet."
             },
-            "geo": {
-              "type": "object",
-              "description": "Geographic location for the post",
-              "properties": {
-                "place_id": {
-                  "type": "string",
-                  "description": "Place ID for the location"
-                }
-              },
-              "required": ["place_id"],
-              "visible": ["place_id"],
-              "additionalProperties": false
-            },
-            "for_super_followers_only": {
+            "share_with_followers": {
               "type": "boolean",
-              "description": "Whether the post is for Super Followers only",
+              "description": "Share community post with followers too.",
               "default": false
             }
           },
           "required": [],
-          "visible": ["text", "media", "poll", "reply", "quote_tweet_id", "reply_settings", "geo", "for_super_followers_only"],
+          "visible": ["text", "card_uri", "community_id", "direct_message_deep_link", "for_super_followers_only", "geo", "media", "nullcast", "poll", "quote_tweet_id", "reply", "reply_settings", "share_with_followers"],
           "additionalProperties": false
         }
       },

--- a/backend/apps/x_com/functions.json
+++ b/backend/apps/x_com/functions.json
@@ -221,7 +221,7 @@
     "name": "X_COM__GET_POST_RETWEETS",
     "description": "Get users who have retweeted a specific post. Returns user information for those who retweeted.",
     "tags": ["posts", "retweets", "users"],
-    "visibility": "public", 
+    "visibility": "public",
     "active": true,
     "protocol": "rest",
     "protocol_data": {
@@ -606,7 +606,7 @@
             "user.fields": {
               "type": "string",
               "description": "Comma-separated list of user fields to include",
-              "default": "id,name,username"  
+              "default": "id,name,username"
             },
             "expansions": {
               "type": "string",
@@ -748,7 +748,7 @@
     "name": "X_COM__GET_USER_FOLLOWED_LISTS",
     "description": "Get lists that a specific user follows. Returns list information for lists they follow.",
     "tags": ["lists", "users", "following"],
-    "visibility": "public",  
+    "visibility": "public",
     "active": true,
     "protocol": "rest",
     "protocol_data": {
@@ -1020,5 +1020,147 @@
       "visible": ["query"],
       "additionalProperties": false
     }
+  },
+  {
+    "name": "X_COM__PUBLISH_POST",
+    "description": "Creates and publishes a new post on X.com. Supports text content, media attachments, polls, reply settings, and other advanced features.",
+    "tags": ["posts", "create", "publish", "tweet"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/2/tweets",
+      "server_url": "https://api.x.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "header": {
+          "type": "object",
+          "description": "HTTP headers",
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          "required": ["Content-Type"],
+          "visible": [],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Request body for creating a post",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The content of the post. Required if media is not provided.",
+              "maxLength": 280
+            },
+            "media": {
+              "type": "object",
+              "description": "Media to attach to the post",
+              "properties": {
+                "media_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Array of media IDs to attach"
+                },
+                "tagged_user_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Array of user IDs to tag in media"
+                }
+              },
+              "required": [],
+              "visible": ["media_ids", "tagged_user_ids"],
+              "additionalProperties": false
+            },
+            "poll": {
+              "type": "object",
+              "description": "Poll to include in the post",
+              "properties": {
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 2,
+                  "maxItems": 4,
+                  "description": "Poll options (2-4 options required)"
+                },
+                "duration_minutes": {
+                  "type": "integer",
+                  "minimum": 5,
+                  "maximum": 10080,
+                  "description": "Poll duration in minutes (5 minutes to 7 days)"
+                }
+              },
+              "required": ["options", "duration_minutes"],
+              "visible": ["options", "duration_minutes"],
+              "additionalProperties": false
+            },
+            "reply": {
+              "type": "object",
+              "description": "Reply settings for the post",
+              "properties": {
+                "in_reply_to_tweet_id": {
+                  "type": "string",
+                  "description": "ID of the post being replied to"
+                },
+                "exclude_reply_user_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "User IDs to exclude from reply notifications"
+                }
+              },
+              "required": [],
+              "visible": ["in_reply_to_tweet_id", "exclude_reply_user_ids"],
+              "additionalProperties": false
+            },
+            "quote_tweet_id": {
+              "type": "string",
+              "description": "ID of the post being quoted"
+            },
+            "reply_settings": {
+              "type": "string",
+              "enum": ["everyone", "mentionedUsers", "following"],
+              "description": "Who can reply to this post"
+            },
+            "geo": {
+              "type": "object",
+              "description": "Geographic location for the post",
+              "properties": {
+                "place_id": {
+                  "type": "string",
+                  "description": "Place ID for the location"
+                }
+              },
+              "required": ["place_id"],
+              "visible": ["place_id"],
+              "additionalProperties": false
+            },
+            "for_super_followers_only": {
+              "type": "boolean",
+              "description": "Whether the post is for Super Followers only",
+              "default": false
+            }
+          },
+          "required": [],
+          "visible": ["text", "media", "poll", "reply", "quote_tweet_id", "reply_settings", "geo", "for_super_followers_only"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["header", "body"],
+      "visible": ["body"],
+      "additionalProperties": false
+    }
   }
-] 
+]


### PR DESCRIPTION
🏷️ Ticket
https://www.notion.so/X-com-integration-OAuth-2-0-integration-2468378d6a478061958bc6b1dd5c4a7c?source=copy_link

📝 Description
This PR is to fix the error that x.com oauth2 integration doesn't work in ACI

I made some changes in backend/aci/server/routes/linked_accounts.py and backend/aci/common/schemas/linked_accounts.py and it works now.

Changes I made:

Shortened the OAuth2 state we send to providers to reduce the risk of invalid_request errors due to state size limits (e.g., x.com ~500 chars - [source: Why is there a state paramter limit for OAuth2 authorization requests? - X developers forum](https://devcommunity.x.com/t/why-is-there-a-state-paramter-limit-for-oauth2-authorization-requests/164824)).
Made redirect_uri optional in the state model (str | None = None) and recompute it on callback instead of embedding it in state.
Rewrite the security_schemes part in x_com/app.json, change it to oauth2 and using correct scopes

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
