### PR TITLE
skip install playwright dependency

### DIFF
--- a/backend/Dockerfile.server
+++ b/backend/Dockerfile.server
@@ -9,7 +9,7 @@ RUN uv sync --no-dev --no-install-project
 ENV PATH="/workdir/.venv/bin:$PATH"
 ENV PYTHONPATH=/workdir
 
-RUN playwright install chromium --with-deps --no-shell
+# RUN playwright install chromium --with-deps --no-shell
 
 # .env files will be skipped by default specified in .dockerignore
 COPY ./aci/server /workdir/aci/server


### PR DESCRIPTION
### 📝 Description
Skip install playwright dependency because it has issue installing when buildling image

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip Playwright installation in the backend Docker build to prevent image build failures caused by the Chromium install. This unblocks building and deploying the server image.

- **Bug Fixes**
  - Commented out the Playwright Chromium install step in backend/Dockerfile.server.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined backend container build by removing a headless browser dependency from the image build process, reducing image size and build time.
  * Improves reliability of builds in environments without system-level browser dependencies.
  * No changes to user-facing features, APIs, or behavior.
  * Deployments may experience faster image pulls and slightly quicker startup due to the lighter image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->