### PR TITLE
fix: fixing function selection dialog overflow issue

### DIFF
--- a/frontend/src/components/appconfig/function-selection-dialog.tsx
+++ b/frontend/src/components/appconfig/function-selection-dialog.tsx
@@ -149,7 +149,7 @@ export function FunctionSelectionDialog({
         <DialogHeader>
           <DialogTitle>Enable/Disable functions</DialogTitle>
         </DialogHeader>
-        <div className="mt-2">
+        <div className="mt-2 overflow-y-auto max-h-[70vh]">
           <FunctionSelection
             availableFunctions={functions}
             isAllFunctionsEnabled={isAllFunctionsEnabled}


### PR DESCRIPTION
### 🏷️ Ticket
https://www.notion.so/Fix-scrolling-on-function-enable-list-2558378d6a47801788c1eb5f3cfd708e?v=c135b6e7f76243819caf99a83e291380&source=copy_link

### 📝 Description
fixing function selection dialog overflow issue

### 📸 Screenshots (if applicable)
Before
<img width="1148" height="824" alt="Screenshot 2025-08-20 at 11 42 34" src="https://github.com/user-attachments/assets/4e05427f-68cb-4938-9570-5c46a3fcd2a7" />

After
<img width="1149" height="807" alt="Screenshot 2025-08-20 at 11 42 42" src="https://github.com/user-attachments/assets/85a61b23-024f-43ff-b8d3-44cb9529135b" />


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed overflow in the Function Selection dialog. The list is now scrollable with a 70vh max height to prevent content from spilling off-screen, especially on smaller screens.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Function Selection dialog now supports vertical scrolling, preventing content from being cut off on smaller screens or with long lists. Improves usability and accessibility.

* **Style**
  * Adjusted layout to maintain consistent spacing and enable smooth in-dialog scrolling, keeping the dialog within a comfortable portion of the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->