### PR TITLE
fix(reddit oauth2): Fix Reddit OAuth2 authorization flow by removing unsupported params

### DIFF
--- a/backend/aci/server/oauth2_manager.py
+++ b/backend/aci/server/oauth2_manager.py
@@ -98,15 +98,22 @@ class OAuth2Manager:
         # - "scope" can be specified here
         # - "response_type" can be specified here (default is "code")
         # - and additional options can be specified here (like access_type, prompt, etc.)
-        authorization_url, _ = self.oauth2_client.create_authorization_url(
-            url=self.authorize_url,
-            redirect_uri=redirect_uri,
-            state=state,
-            code_verifier=code_verifier,
-            access_type=access_type,
-            prompt=prompt,
-            scope=self.scope,
+        # Reddit does not support Google-style params like access_type/prompt. Build kwargs accordingly.
+        create_auth_kwargs = {
+            "url": self.authorize_url,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_verifier": code_verifier,
+            "scope": self.scope,
             **app_specific_params,
+        }
+
+        if self.app_name != "REDDIT":
+            create_auth_kwargs["access_type"] = access_type
+            create_auth_kwargs["prompt"] = prompt
+
+        authorization_url, _ = self.oauth2_client.create_authorization_url(
+            **create_auth_kwargs
         )
 
         return str(authorization_url)


### PR DESCRIPTION
### 🏷️ Ticket

n/a

### 📝 Description

- Reddit’s authorize endpoint only supports `client_id`, `response_type=code`, `state`, `redirect_uri`, `duration`, and `scope`. We were also sending Google-specific params (`access_type`, `prompt`), which Reddit does not support. 
- Docs: [Reddit OAuth2 wiki](https://github.com/reddit-archive/reddit/wiki/OAuth2)

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

Screenshots after fix & finished oauth2 login (the success callback page)
<img width="594" height="423" alt="Screenshot 2025-09-08 at 17 13 19" src="https://github.com/user-attachments/assets/47e99090-404b-41d0-9756-57764c9bf90f" />

Screenshots with running the fuzzy test prompts (successful)
<img width="876" height="573" alt="Screenshot 2025-09-08 at 17 18 11" src="https://github.com/user-attachments/assets/06b425d8-a9bf-48c0-92d9-589cf6791bf8" />
fuzzy test prompt that i executed:
```
docker compose exec runner python -m aci.cli fuzzy-test-function-execution \
  --function-name REDDIT__GET_SUBREDDIT_INFO \
  --linked-account-owner-id <LINKED_ACCOUNT_ID> \
  --aci-api-key <ACI_API_KEY> \
  --prompt "Get subreddit info for 'python'"
```


### ✅ Checklist

- [x] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Reddit OAuth2 by removing unsupported authorize params (access_type, prompt) to stop “Bad request (reddit.com)” errors and allow successful login.

- **Bug Fixes**
  - Exclude access_type and prompt when app_name is REDDIT; keep them for other providers.
  - Build authorization kwargs safely so only Reddit-supported params are sent.

<!-- End of auto-generated description by cubic. -->


<!-- RECURSEML_SUMMARY:START -->
## Review by RecurseML

 _🔍 Review performed on [2c12d12..fc393b7](https://github.com/aipotheosis-labs/aci/compare/2c12d1202840c3b3d5b6d104a086da3dd2c41bb6...fc393b751636963dcc02d0b7cf0d51810b001d1d)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `backend/aci/server/oauth2_manager.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in reliability by applying provider-specific parameters during authorization.
  * Reddit sign-in now uses permanent duration without unnecessary access_type/prompt parameters, reducing errors.
  * Other providers correctly receive access_type and prompt where applicable, minimizing extra consent prompts and improving user flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->