### PR TITLE
Add Codex plugin quality gate CI

### DIFF
--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high


### PR DESCRIPTION
Adds a CI workflow to validate Codex plugin manifests using the HOL Codex Plugin Scanner.

This workflow runs on any PR modifying plugin files and ensures manifest structure, skills, and MCP config are valid with a minimum quality score of 80/100.

Scanner: codex-plugin-scanner | awesome-codex-plugins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions quality gate that scans Codex plugin manifests and configs on PRs. Blocks merges if the score is below 80 or any high-severity issues are found.

- **New Features**
  - Runs on PRs touching `.codex-plugin/**`, `skills/**`, or `.mcp.json`.
  - Uses `hashgraph-online/hol-codex-plugin-scanner-action@v1` with `plugin_dir: "."`, `min_score: 80`, and `fail_on_severity: high`.
  - Validates manifest structure, skills, and MCP config.

<sup>Written for commit 5c3f7394f97ee07858a6ec52d88bec27148d111e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated quality validation for pull requests affecting plugins and skills to enforce quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->