### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/integration_code_review.yml
+++ b/.github/workflows/integration_code_review.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Get PR title and body
         id: pr-info
         if: steps.changed-files.outputs.skip != 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          echo "title=$PR_TITLE" >> $GITHUB_OUTPUT
           echo "body<<BODY_DELIMITER" >> $GITHUB_OUTPUT
-          echo "${{ github.event.pull_request.body }}" >> $GITHUB_OUTPUT
+          echo "$PR_BODY" >> $GITHUB_OUTPUT
           echo "BODY_DELIMITER" >> $GITHUB_OUTPUT
 
       - name: Generate file content for Claude


### PR DESCRIPTION
Potential fix for [https://github.com/aipotheosis-labs/aci/security/code-scanning/2](https://github.com/aipotheosis-labs/aci/security/code-scanning/2)

General fix: never place untrusted GitHub expression values directly inside `run:`/`script:` command text. Instead, map them into step `env:` variables and reference them using native shell variables (e.g., `"$PR_BODY"`), which avoids expression-time code injection.

Best targeted fix here (without changing functionality): in `.github/workflows/integration_code_review.yml`, update the **Get PR title and body** step to:
1. Add `env:` entries for PR title/body from GitHub expressions.
2. Replace `${{ github.event.pull_request.title }}` and `${{ github.event.pull_request.body }}` inside `run:` with `"$PR_TITLE"` and `"$PR_BODY"` respectively.

This preserves current behavior (writing `title` and multiline `body` to `$GITHUB_OUTPUT`) while removing unsafe direct interpolation in shell commands.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD workflow reliability by refactoring environment variable handling in the code review process.

---

**Note:** This release contains no end-user visible changes. Updates are internal to development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->